### PR TITLE
몬스터 통합 검색 기능 API

### DIFF
--- a/src/main/java/com/maple/api/common/presentation/config/SecurityConfig.java
+++ b/src/main/java/com/maple/api/common/presentation/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
           .requestMatchers("/swagger-ui-maple/**").permitAll()
           .requestMatchers("/v3/api-docs/**").permitAll()
           .requestMatchers("/api/v1/search/**").permitAll()
+          .requestMatchers("/api/v1/monsters/**").permitAll()
           .anyRequest().authenticated()
       )
       .with(jwtSecurityAdapter, Customizer.withDefaults());

--- a/src/main/java/com/maple/api/monster/application/MonsterService.java
+++ b/src/main/java/com/maple/api/monster/application/MonsterService.java
@@ -1,0 +1,22 @@
+package com.maple.api.monster.application;
+
+import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
+import com.maple.api.monster.application.dto.MonsterSummaryDto;
+import com.maple.api.monster.repository.MonsterQueryDslRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MonsterService {
+
+    private final MonsterQueryDslRepository monsterQueryDslRepository;
+
+    @Transactional(readOnly = true)
+    public Page<MonsterSummaryDto> searchMonsters(MonsterSearchRequestDto request, Pageable pageable) {
+        return monsterQueryDslRepository.searchMonsters(request, pageable).map(MonsterSummaryDto::toDto);
+    }
+}

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterSearchRequestDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterSearchRequestDto.java
@@ -1,0 +1,13 @@
+package com.maple.api.monster.application.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record MonsterSearchRequestDto(
+        String keyword,
+        @Min(1)
+        Integer minLevel,
+        @Max(200)
+        Integer maxLevel
+) {
+}

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
@@ -1,0 +1,19 @@
+package com.maple.api.monster.application.dto;
+
+import com.maple.api.monster.domain.Monster;
+
+public record MonsterSummaryDto(
+        Integer monsterId,
+        String name,
+        String imageUrl,
+        String type
+) {
+    public static MonsterSummaryDto toDto(Monster entity) {
+        return new MonsterSummaryDto(
+                entity.getMonsterId(),
+                entity.getNameKr(),
+                entity.getImageUrl(),
+                "monster"
+        );
+    }
+}

--- a/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
+++ b/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
@@ -1,0 +1,30 @@
+package com.maple.api.monster.presentation.restapi;
+
+import com.maple.api.monster.application.MonsterService;
+import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
+import com.maple.api.monster.application.dto.MonsterSummaryDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/monsters")
+@RequiredArgsConstructor
+public class MonsterController {
+
+    private final MonsterService monsterService;
+
+    @GetMapping
+    public ResponseEntity<Page<MonsterSummaryDto>> searchMonsters(
+            @Valid @ModelAttribute MonsterSearchRequestDto request,
+            @PageableDefault(size = 20, sort = "monsterId") Pageable pageable) {
+        return ResponseEntity.ok(monsterService.searchMonsters(request, pageable));
+    }
+}

--- a/src/main/java/com/maple/api/monster/repository/MonsterQueryDslRepository.java
+++ b/src/main/java/com/maple/api/monster/repository/MonsterQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.maple.api.monster.repository;
+
+import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
+import com.maple.api.monster.domain.Monster;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MonsterQueryDslRepository {
+    Page<Monster> searchMonsters(MonsterSearchRequestDto request, Pageable pageable);
+}

--- a/src/main/java/com/maple/api/monster/repository/MonsterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/monster/repository/MonsterQueryDslRepositoryImpl.java
@@ -1,0 +1,123 @@
+package com.maple.api.monster.repository;
+
+import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
+import com.maple.api.monster.domain.Monster;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.maple.api.monster.domain.QMonster.monster;
+
+@Repository
+@RequiredArgsConstructor
+public class MonsterQueryDslRepositoryImpl implements MonsterQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Monster> searchMonsters(MonsterSearchRequestDto request, Pageable pageable) {
+        // 1. WHERE 절 생성
+        BooleanBuilder whereClause = createWhereClause(request);
+
+        // 2. ORDER BY 절 생성
+        List<OrderSpecifier<?>> orderClause = createOrderClause(pageable);
+
+        // 3. 최적화된 ID 목록 조회
+        List<Integer> monsterIds = fetchMonsterIds(whereClause, orderClause, pageable);
+        if (monsterIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 4. ID 목록으로 실제 컨텐츠 조회
+        List<Monster> content = fetchContent(monsterIds, orderClause);
+
+        // 5. 전체 카운트 쿼리 생성
+        JPAQuery<Long> countQuery = createCountQuery(whereClause);
+
+        // 6. Page 객체로 변환하여 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanBuilder createWhereClause(MonsterSearchRequestDto request) {
+        BooleanBuilder builder = new BooleanBuilder();
+        if (StringUtils.hasText(request.keyword())) {
+            builder.and(monster.nameKr.containsIgnoreCase(request.keyword().trim()));
+        }
+        if (request.minLevel() != null) {
+            builder.and(monster.level.goe(request.minLevel()));
+        }
+        if (request.maxLevel() != null) {
+            builder.and(monster.level.loe(request.maxLevel()));
+        }
+        return builder;
+    }
+
+    private List<OrderSpecifier<?>> createOrderClause(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return List.of(monster.monsterId.asc());
+        }
+
+        Map<String, Path<?>> sortableProperties = Map.of(
+                "name", monster.nameKr,
+                "level", monster.level,
+                "exp", monster.exp
+        );
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        if (pageable.getSort().isUnsorted()) {
+            orderSpecifiers.add(monster.monsterId.asc());
+            return orderSpecifiers;
+        }
+
+        pageable.getSort().forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path));
+            }
+        });
+
+
+        orderSpecifiers.add(monster.monsterId.asc());
+        return orderSpecifiers;
+    }
+
+    private List<Integer> fetchMonsterIds(BooleanBuilder where, List<OrderSpecifier<?>> order, Pageable pageable) {
+        return queryFactory
+                .select(monster.monsterId)
+                .from(monster)
+                .where(where)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private List<Monster> fetchContent(List<Integer> monsterIds, List<OrderSpecifier<?>> order) {
+        return queryFactory
+                .selectFrom(monster)
+                .where(monster.monsterId.in(monsterIds))
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private JPAQuery<Long> createCountQuery(BooleanBuilder where) {
+        return queryFactory
+                .select(monster.count())
+                .from(monster)
+                .where(where);
+    }
+
+}


### PR DESCRIPTION
### 요약
기존에 구현된 통합 검색 API의 초기 버전을 참고해서 성능, 가독성, 유지보수성을 높이기 위해 아이템 전용 통합 검색 기능 API를 만들었습니다.

### 구현 내용 사항
- 몬스터 필터링 구현 : 레벨
- Job Entity에 상수(COMMON_JOB_ID) 추가 -> 필터링 시 거의 항상 공용은 포함되어야 하는데, 하드코딩을 없애기 위해 Entity에 상수를 추가했습니다.
키워드 검색 구현: 키워드 검색을 LIKE 문으로 부분 문자열 검색
정렬: 스프링 Pageable 사용
페이징: 스프링 Pageable 사용, page 및 size로 페이지네이션 가능(page는 0번 부터)