### PR TITLE
코드 개선, GlobalExceptionHandler 추가, 스웨거 문서 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/maple/api/common/presentation/exception/ApiException.java
+++ b/src/main/java/com/maple/api/common/presentation/exception/ApiException.java
@@ -1,0 +1,27 @@
+package com.maple.api.common.presentation.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    
+    private final ExceptionCode exceptionCode;
+
+    public ApiException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+
+    public ApiException(ExceptionCode exceptionCode, Throwable cause) {
+        super(exceptionCode.getMessage(), cause);
+        this.exceptionCode = exceptionCode;
+    }
+
+    public static ApiException of(ExceptionCode exceptionCode) {
+        return new ApiException(exceptionCode);
+    }
+
+    public static ApiException of(ExceptionCode exceptionCode, Throwable cause) {
+        return new ApiException(exceptionCode, cause);
+    }
+}

--- a/src/main/java/com/maple/api/common/presentation/exception/ExceptionCode.java
+++ b/src/main/java/com/maple/api/common/presentation/exception/ExceptionCode.java
@@ -1,0 +1,8 @@
+package com.maple.api.common.presentation.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+    String getMessage();
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/maple/api/common/presentation/exception/ExceptionResponse.java
+++ b/src/main/java/com/maple/api/common/presentation/exception/ExceptionResponse.java
@@ -1,0 +1,52 @@
+package com.maple.api.common.presentation.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ExceptionResponse {
+    
+    private final String message;
+    private final LocalDateTime timestamp;
+    private final String path;
+    private final Object details;
+    
+    public static ExceptionResponse of(String message, String path) {
+        return ExceptionResponse.builder()
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .build();
+    }
+    
+    public static ExceptionResponse of(String message, String path, Object details) {
+        return ExceptionResponse.builder()
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .details(details)
+                .build();
+    }
+    
+    public static ExceptionResponse of(ExceptionCode exceptionCode, String path) {
+        return ExceptionResponse.builder()
+                .message(exceptionCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .build();
+    }
+    
+    public static ExceptionResponse of(ExceptionCode exceptionCode, String path, Object details) {
+        return ExceptionResponse.builder()
+                .message(exceptionCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .details(details)
+                .build();
+    }
+}

--- a/src/main/java/com/maple/api/common/presentation/exception/GlobalException.java
+++ b/src/main/java/com/maple/api/common/presentation/exception/GlobalException.java
@@ -1,0 +1,27 @@
+package com.maple.api.common.presentation.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalException implements ExceptionCode {
+
+    // 검증 및 파라미터 예외
+    VALIDATION_FAILED("입력값 검증에 실패했습니다.", BAD_REQUEST),
+    BIND_FAILED("요청 파라미터 바인딩에 실패했습니다.", BAD_REQUEST),
+    CONSTRAINT_VIOLATION("제약 조건 위반입니다.", BAD_REQUEST),
+    INVALID_ARGUMENT("잘못된 인수입니다.", BAD_REQUEST),
+    
+    // 404
+    RESOURCE_NOT_FOUND("리소스가 존재하지 않습니다.", NOT_FOUND),
+    
+    // 서버 예외
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/common/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/maple/api/common/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,121 @@
+package com.maple.api.common.presentation.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleValidationException(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                GlobalException.VALIDATION_FAILED,
+                request.getRequestURI(),
+                errors
+        );
+        
+        log.warn("Validation failed: {}", errors);
+        return ResponseEntity.status(GlobalException.VALIDATION_FAILED.getStatus()).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ExceptionResponse> handleBindException(
+            BindException ex, HttpServletRequest request) {
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                GlobalException.BIND_FAILED,
+                request.getRequestURI(),
+                errors
+        );
+        
+        log.warn("Bind failed: {}", errors);
+        return ResponseEntity.status(GlobalException.BIND_FAILED.getStatus()).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ExceptionResponse> handleConstraintViolationException(
+            ConstraintViolationException ex, HttpServletRequest request) {
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(violation -> {
+            String propertyPath = violation.getPropertyPath().toString();
+            String message = violation.getMessage();
+            errors.put(propertyPath, message);
+        });
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                GlobalException.CONSTRAINT_VIOLATION,
+                request.getRequestURI(),
+                errors
+        );
+        
+        log.warn("Constraint violation: {}", errors);
+        return ResponseEntity.status(GlobalException.CONSTRAINT_VIOLATION.getStatus()).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionResponse> handleIllegalArgumentException(
+            IllegalArgumentException ex, HttpServletRequest request) {
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        
+        log.warn("Invalid argument: {}", ex.getMessage());
+        return ResponseEntity.status(GlobalException.INVALID_ARGUMENT.getStatus()).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ExceptionResponse> handleApiException(
+            ApiException ex, HttpServletRequest request) {
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                ex.getExceptionCode(),
+                request.getRequestURI()
+        );
+        
+        log.warn("API exception occurred: {}", ex.getMessage());
+        return ResponseEntity.status(ex.getExceptionCode().getStatus()).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleGenericException(
+            Exception ex, HttpServletRequest request) {
+        
+        ExceptionResponse exceptionResponse = ExceptionResponse.of(
+                GlobalException.INTERNAL_SERVER_ERROR,
+                request.getRequestURI()
+        );
+        
+        log.error("Unexpected error occurred", ex);
+        return ResponseEntity.status(GlobalException.INTERNAL_SERVER_ERROR.getStatus()).body(exceptionResponse);
+    }
+}

--- a/src/main/java/com/maple/api/item/application/CategoryService.java
+++ b/src/main/java/com/maple/api/item/application/CategoryService.java
@@ -1,7 +1,9 @@
 package com.maple.api.item.application;
 
+import com.maple.api.common.presentation.exception.ApiException;
 import com.maple.api.item.application.dto.CategoryDto;
 import com.maple.api.item.domain.Category;
+import com.maple.api.item.exception.ItemException;
 import com.maple.api.item.repository.CategoryRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +43,7 @@ public class CategoryService {
     public Category findById(Integer categoryId) {
         Category category = categoryCache.get(categoryId);
         if (category == null) {
-            throw new IllegalArgumentException("Category not found id: " + categoryId);
+            throw ApiException.of(ItemException.CATEGORY_NOT_FOUND);
         }
         return category;
     }
@@ -49,11 +51,11 @@ public class CategoryService {
     public Category findRootCategory(Integer categoryId) {
         Integer rootCategoryId = rootCategoryCache.get(categoryId);
         if (rootCategoryId == null) {
-            throw new IllegalArgumentException("Root category not found child id: " + categoryId);
+            throw ApiException.of(ItemException.CATEGORY_NOT_FOUND);
         }
         Category rootCategory = categoryCache.get(rootCategoryId);
         if (rootCategory == null) {
-            throw new IllegalArgumentException("Root category not found id: " + rootCategoryId);
+            throw ApiException.of(ItemException.CATEGORY_NOT_FOUND);
         }
         return rootCategory;
     }

--- a/src/main/java/com/maple/api/item/application/CategoryService.java
+++ b/src/main/java/com/maple/api/item/application/CategoryService.java
@@ -27,16 +27,16 @@ public class CategoryService {
     @PostConstruct
     public void initializeCache() {
         List<Category> categories = categoryRepository.findAll();
-        
+
         for (Category category : categories) {
             categoryCache.put(category.getCategoryId(), category);
         }
-        
+
         for (Category category : categories) {
             Integer rootCategoryId = findRootCategoryId(category.getCategoryId());
             rootCategoryCache.put(category.getCategoryId(), rootCategoryId);
         }
-        
+
         this.categoryTreeCache = buildAndCacheCategoryTree();
     }
 
@@ -63,17 +63,17 @@ public class CategoryService {
     private Integer findRootCategoryId(Integer categoryId) {
         Category current = categoryCache.get(categoryId);
         if (current == null) {
-            return null;
+            throw ApiException.of(ItemException.CATEGORY_NOT_FOUND);
         }
         
         while (current.getParentCategoryId() != null) {
             current = categoryCache.get(current.getParentCategoryId());
             if (current == null) {
-                break;
+                throw ApiException.of(ItemException.PARENT_CATEGORY_NOT_FOUND);
             }
         }
         
-        return current != null ? current.getCategoryId() : null;
+        return current.getCategoryId();
     }
 
     public List<CategoryDto> getAllCategories() {

--- a/src/main/java/com/maple/api/item/application/ItemService.java
+++ b/src/main/java/com/maple/api/item/application/ItemService.java
@@ -1,5 +1,6 @@
 package com.maple.api.item.application;
 
+import com.maple.api.common.presentation.exception.ApiException;
 import com.maple.api.item.application.dto.ItemDetailDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.application.dto.ItemSummaryDto;
@@ -7,10 +8,11 @@ import com.maple.api.item.domain.Category;
 import com.maple.api.item.domain.EquipmentItem;
 import com.maple.api.item.domain.Item;
 import com.maple.api.item.domain.ScrollItem;
+import com.maple.api.item.exception.ItemException;
 import com.maple.api.item.repository.ItemQueryDslRepository;
 import com.maple.api.item.repository.ItemRepository;
-import com.maple.api.job.repository.JobRepository;
 import com.maple.api.job.domain.Job;
+import com.maple.api.job.repository.JobRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,7 +40,7 @@ public class ItemService {
     @Transactional(readOnly = true)
     public ItemDetailDto getItemDetail(Integer itemId) {
         Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new IllegalArgumentException("Item not found with id: " + itemId));
+                .orElseThrow(() -> ApiException.of(ItemException.ITEM_NOT_FOUND));
 
         item = loadTypeSpecificData(item);
 
@@ -53,10 +55,10 @@ public class ItemService {
     private Item loadTypeSpecificData(Item item) {
         if (item instanceof EquipmentItem) {
             return itemRepository.findEquipmentDetailById(item.getItemId())
-                    .orElseThrow(() -> new IllegalArgumentException("Item not found with id: " + item.getItemId()));
+                    .orElseThrow(() -> ApiException.of(ItemException.ITEM_NOT_FOUND));
         } else if (item instanceof ScrollItem) {
             return itemRepository.findScrollDetailById(item.getItemId())
-                    .orElseThrow(() -> new IllegalArgumentException("Item not found with id: " + item.getItemId()));
+                    .orElseThrow(() -> ApiException.of(ItemException.ITEM_NOT_FOUND));
         } else {
             return item;
         }

--- a/src/main/java/com/maple/api/item/application/dto/CategoryDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/CategoryDto.java
@@ -1,14 +1,25 @@
 package com.maple.api.item.application.dto;
 
 import com.maple.api.item.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "카테고리 정보")
 public record CategoryDto(
+        @Schema(description = "카테고리 ID", example = "2")
         Integer categoryId,
+        
+        @Schema(description = "카테고리 이름", example = "무기")
         String name,
+        
+        @Schema(description = "카테고리 레벨 (계층 구조)", example = "1")
         Integer categoryLevel,
+        
+        @Schema(description = "카테고리 설명", example = "모든 종류의 무기")
         String description,
+        
+        @Schema(description = "하위 카테고리 목록")
         List<CategoryDto> children
 ) {
     public static CategoryDto toDto(Category category) {

--- a/src/main/java/com/maple/api/item/application/dto/ItemDetailDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemDetailDto.java
@@ -3,23 +3,48 @@ package com.maple.api.item.application.dto;
 import com.maple.api.item.domain.*;
 import com.maple.api.job.domain.Job;
 import com.maple.api.job.application.dto.JobDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
+@Schema(description = "아이템 상세 정보 DTO")
 public record ItemDetailDto(
+        @Schema(description = "아이템 ID", example = "1002001")
         Integer itemId,
+        
+        @Schema(description = "아이템명 (한국어)", example = "메탈 기어")
         String nameKr,
+        
+        @Schema(description = "아이템명 (영어)", example = "Metal Gear")
         String nameEn,
+        
+        @Schema(description = "아이템 설명", example = "메탈 기어입니다.")
         String descriptionText,
+        
+        @Schema(description = "아이템 이미지 URL", example = "https://maplestory.io/api/gms/62/item/1002001/icon?resize=2")
         String itemImageUrl,
+        
+        @Schema(description = "NPC 판매 가격", example = "1500")
         Integer npcPrice,
+        
+        @Schema(description = "아이템 타입", example = "EQUIPMENT", allowableValues = {"EQUIPMENT", "SCROLL", "OTHER", "UNKNOWN"})
         String itemType,
+        
+        @Schema(description = "카테고리 계층 정보")
         CategoryHierarchyDto categoryHierarchy,
+        
+        @Schema(description = "착용 가능한 직업 목록")
         List<JobDto> availableJobs,
+        
+        @Schema(description = "필요 스탯 정보 (장비 아이템의 경우)")
         RequiredStatsDto requiredStats,
+        
+        @Schema(description = "장비 스탯 정보 (장비 아이템의 경우)")
         ItemEquipmentStatsDto equipmentStats,
+        
+        @Schema(description = "스크롤 상세 정보 (스크롤 아이템의 경우)")
         ItemScrollDetailDto scrollDetail
 ) {
     

--- a/src/main/java/com/maple/api/item/application/dto/ItemSearchRequestDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemSearchRequestDto.java
@@ -1,17 +1,50 @@
 package com.maple.api.item.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import java.util.List;
 
+@Schema(description = "아이템 검색 요청 DTO")
 public record ItemSearchRequestDto(
+        @Schema(
+            description = "검색 키워드 (아이템명으로 검색)",
+            example = "메탈 기어",
+            nullable = true
+        )
         String keyword,
+        
+        @Schema(
+            description = "직업 ID (특정 직업 착용 가능한 아이템만 검색)",
+            example = "5",
+            nullable = true
+        )
         Integer jobId,
+        
+        @Schema(
+            description = "최소 요구 레벨 (1-200)",
+            example = "10",
+            minimum = "1",
+            nullable = true
+        )
         @Min(value = 1, message = "최소 레벨은 1 이상이어야 합니다")
         Integer minLevel,
+        
+        @Schema(
+            description = "최대 요구 레벨 (1-200)",
+            example = "100",
+            maximum = "200",
+            nullable = true
+        )
         @Max(value = 200, message = "최대 레벨은 200 이하여야 합니다")
         Integer maxLevel,
+        
+        @Schema(
+            description = "카테고리 ID 목록 (특정 카테고리의 아이템만 검색)",
+            example = "[24, 25]",
+            nullable = true
+        )
         List<Integer> categoryIds
 ) {
 }

--- a/src/main/java/com/maple/api/item/application/dto/ItemSummaryDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemSummaryDto.java
@@ -1,8 +1,22 @@
 package com.maple.api.item.application.dto;
 
 import com.maple.api.item.domain.Item;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ItemSummaryDto(Integer itemId, String name, String imageUrl, String type) {
+@Schema(description = "아이템 요약 정보 DTO")
+public record ItemSummaryDto(
+        @Schema(description = "아이템 ID", example = "1002001")
+        Integer itemId,
+        
+        @Schema(description = "아이템명", example = "메탈 기어")
+        String name,
+        
+        @Schema(description = "아이템 이미지 URL", example = "https://maplestory.io/api/gms/62/item/1002001/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "아이템 타입 (고정값: 'item')", example = "item")
+        String type
+) {
     public static ItemSummaryDto toDto(Item entity) {
         return new ItemSummaryDto(
                 entity.getItemId(), 

--- a/src/main/java/com/maple/api/item/exception/ItemException.java
+++ b/src/main/java/com/maple/api/item/exception/ItemException.java
@@ -1,0 +1,20 @@
+package com.maple.api.item.exception;
+
+import com.maple.api.common.presentation.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@RequiredArgsConstructor
+public enum ItemException implements ExceptionCode {
+
+    // 아이템 관련 예외
+    ITEM_NOT_FOUND("아이템을 찾을 수 없습니다.", NOT_FOUND),
+    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다.", NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/item/exception/ItemException.java
+++ b/src/main/java/com/maple/api/item/exception/ItemException.java
@@ -13,7 +13,8 @@ public enum ItemException implements ExceptionCode {
 
     // 아이템 관련 예외
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다.", NOT_FOUND),
-    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다.", NOT_FOUND);
+    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다.", NOT_FOUND),
+    PARENT_CATEGORY_NOT_FOUND("상위 카테고리를 찾을 수 없습니다.", NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/maple/api/item/presentation/restapi/CategoryController.java
+++ b/src/main/java/com/maple/api/item/presentation/restapi/CategoryController.java
@@ -3,6 +3,10 @@ package com.maple.api.item.presentation.restapi;
 import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import com.maple.api.item.application.CategoryService;
 import com.maple.api.item.application.dto.CategoryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,11 +16,20 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
+@Tag(name = "Category", description = "아이템 카테고리 관련 API")
 public class CategoryController {
 
     private final CategoryService categoryService;
 
     @GetMapping
+    @Operation(
+        summary = "모든 카테고리 조회",
+        description = "시스템에서 사용 가능한 모든 아이템 카테고리 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<ResponseTemplate<List<CategoryDto>>> getAllCategories() {
         return ResponseEntity.ok(ResponseTemplate.success(categoryService.getAllCategories()));
     }

--- a/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
+++ b/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
@@ -4,36 +4,60 @@ import com.maple.api.item.application.ItemService;
 import com.maple.api.item.application.dto.ItemDetailDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.application.dto.ItemSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/items")
 @RequiredArgsConstructor
+@Tag(name = "Item", description = "아이템 관련 API")
 public class ItemController {
 
     private final ItemService itemService;
 
     @GetMapping
+    @Operation(
+        summary = "아이템 검색",
+        description = "다양한 조건으로 아이템을 검색합니다. 키워드, 직업, 레벨 범위, 카테고리 등으로 필터링할 수 있으며, 정렬 옵션을 제공합니다.\n\n" +
+                     "**정렬 가능한 필드:**\n" +
+                     "- name: 아이템명\n" +
+                     "- level: 요구레벨\n" +
+                     "- itemId: 아이템ID\n\n" +
+                     "**정렬 사용 예시:**\n" +
+                     "- `sort=name,asc` (아이템명 오름차순)\n" +
+                     "- `sort=level,desc` (레벨 내림차순)\n" +
+                     "- `sort=name,asc,level,desc` (아이템명 오름차순, 레벨 내림차순)"
+    )
     public ResponseEntity<Page<ItemSummaryDto>> searchItems(
             @Valid @ParameterObject ItemSearchRequestDto searchRequest,
-            @PageableDefault(size = 20, sort = "name") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable) {
         
         Page<ItemSummaryDto> results = itemService.searchItems(searchRequest, pageable);
         return ResponseEntity.ok(results);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ItemDetailDto> getItemDetail(@PathVariable Integer id) {
+    @Operation(
+        summary = "아이템 상세 조회",
+        description = "아이템 ID로 특정 아이템의 상세 정보를 조회합니다.\n\n" +
+                "장비 아이템의 경우 스탯 정보,\n\n" +
+                "주문서 아이템의 경우 스크롤 정보 등을 포함합니다."
+    )
+    public ResponseEntity<ItemDetailDto> getItemDetail(
+            @Parameter(description = "아이템 ID", example = "1302000", required = true)
+            @PathVariable Integer id) {
         ItemDetailDto itemDetail = itemService.getItemDetail(id);
         return ResponseEntity.ok(itemDetail);
     }

--- a/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
+++ b/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
@@ -1,6 +1,5 @@
 package com.maple.api.item.presentation.restapi;
 
-import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import com.maple.api.item.application.ItemService;
 import com.maple.api.item.application.dto.ItemDetailDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
@@ -25,17 +24,17 @@ public class ItemController {
     private final ItemService itemService;
 
     @GetMapping
-    public ResponseEntity<ResponseTemplate<Page<ItemSummaryDto>>> searchItems(
+    public ResponseEntity<Page<ItemSummaryDto>> searchItems(
             @Valid @ParameterObject ItemSearchRequestDto searchRequest,
             @PageableDefault(size = 20, sort = "name") Pageable pageable) {
         
         Page<ItemSummaryDto> results = itemService.searchItems(searchRequest, pageable);
-        return ResponseEntity.ok(ResponseTemplate.success(results));
+        return ResponseEntity.ok(results);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResponseTemplate<ItemDetailDto>> getItemDetail(@PathVariable Integer id) {
+    public ResponseEntity<ItemDetailDto> getItemDetail(@PathVariable Integer id) {
         ItemDetailDto itemDetail = itemService.getItemDetail(id);
-        return ResponseEntity.ok(ResponseTemplate.success(itemDetail));
+        return ResponseEntity.ok(itemDetail);
     }
 }

--- a/src/main/java/com/maple/api/job/application/dto/JobDto.java
+++ b/src/main/java/com/maple/api/job/application/dto/JobDto.java
@@ -1,11 +1,20 @@
 package com.maple.api.job.application.dto;
 
 import com.maple.api.job.domain.Job;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "직업 정보")
 public record JobDto(
+        @Schema(description = "직업 ID", example = "1")
         Integer jobId,
+        
+        @Schema(description = "직업 이름", example = "초보자")
         String jobName,
+        
+        @Schema(description = "직업 레벨 (전직 단계)", example = "0")
         Integer jobLevel,
+        
+        @Schema(description = "상위 직업 ID (전직 전 직업)", example = "null")
         Integer parentJobId
 ) {
     public static JobDto toDto(Job job) {

--- a/src/main/java/com/maple/api/job/exception/JobException.java
+++ b/src/main/java/com/maple/api/job/exception/JobException.java
@@ -1,0 +1,20 @@
+package com.maple.api.job.exception;
+
+import com.maple.api.common.presentation.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum JobException implements ExceptionCode {
+
+    // 직업 관련 예외
+    JOB_NOT_FOUND("직업을 찾을 수 없습니다.", NOT_FOUND),
+    PARENT_JOB_NOT_FOUND("상위 직업을 찾을 수 없습니다.", NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/job/presentation/restapi/JobController.java
+++ b/src/main/java/com/maple/api/job/presentation/restapi/JobController.java
@@ -1,6 +1,5 @@
 package com.maple.api.job.presentation.restapi;
 
-import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import com.maple.api.job.application.JobService;
 import com.maple.api.job.application.dto.JobDto;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,7 @@ public class JobController {
     private final JobService jobService;
 
     @GetMapping
-    public ResponseEntity<ResponseTemplate<List<JobDto>>> findAllJobs() {
-        return ResponseEntity.ok(ResponseTemplate.success(jobService.findAll()));
+    public ResponseEntity<List<JobDto>> findAllJobs() {
+        return ResponseEntity.ok(jobService.findAll());
     }
 }

--- a/src/main/java/com/maple/api/job/presentation/restapi/JobController.java
+++ b/src/main/java/com/maple/api/job/presentation/restapi/JobController.java
@@ -2,6 +2,10 @@ package com.maple.api.job.presentation.restapi;
 
 import com.maple.api.job.application.JobService;
 import com.maple.api.job.application.dto.JobDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,11 +17,20 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/jobs")
 @RequiredArgsConstructor
+@Tag(name = "Job", description = "직업 관련 API")
 public class JobController {
 
     private final JobService jobService;
 
     @GetMapping
+    @Operation(
+        summary = "모든 직업 조회",
+        description = "메이플스토리에서 사용 가능한 모든 직업 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "직업 목록 조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<List<JobDto>> findAllJobs() {
         return ResponseEntity.ok(jobService.findAll());
     }

--- a/src/main/java/com/maple/api/map/application/dto/MapSearchRequestDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapSearchRequestDto.java
@@ -1,6 +1,10 @@
 package com.maple.api.map.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "맵 검색 요청 정보")
 public record MapSearchRequestDto(
+        @Schema(description = "검색 키워드 (맵 이름)", example = "헤네시스")
         String keyword
 ) {
 }

--- a/src/main/java/com/maple/api/map/application/dto/MapSummaryDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapSummaryDto.java
@@ -1,8 +1,22 @@
 package com.maple.api.map.application.dto;
 
 import com.maple.api.map.domain.Map;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record MapSummaryDto(Integer mapId, String name, String imageUrl, String type) {
+@Schema(description = "맵 요약 정보")
+public record MapSummaryDto(
+        @Schema(description = "맵 ID", example = "100000000")
+        Integer mapId,
+        
+        @Schema(description = "맵 이름", example = "헤네시스")
+        String name,
+        
+        @Schema(description = "맵 이미지 URL", example = "https://maplestory.io/api/gms/62/map/100000000/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "데이터 타입 (고정값: 'map')", example = "map")
+        String type
+) {
     public static MapSummaryDto toDto(Map entity) {
         return new MapSummaryDto(entity.getMapId(), entity.getNameKr(), entity.getIconUrl(), "map");
     }

--- a/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
+++ b/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
@@ -3,6 +3,10 @@ package com.maple.api.map.presentation.restapi;
 import com.maple.api.map.application.MapService;
 import com.maple.api.map.application.dto.MapSearchRequestDto;
 import com.maple.api.map.application.dto.MapSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,14 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/maps")
 @RequiredArgsConstructor
+@Tag(name = "Map", description = "맵 관련 API")
 public class MapController {
 
     private final MapService mapService;
 
     @GetMapping
+    @Operation(
+        summary = "맵 검색",
+        description = "다양한 조건으로 맵을 검색합니다. 맵 이름으로 필터링할 수 있습니다.\n\n" +
+                     "**정렬 기준:**\n" +
+                     "- 기본 정렬 적용\n" +
+                     "- 페이지 크기: 20개 (기본값)"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "맵 검색 결과 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Page<MapSummaryDto>> searchMaps(
             @ParameterObject MapSearchRequestDto request,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         Page<MapSummaryDto> maps = mapService.searchMaps(request, pageable);
         return ResponseEntity.ok(maps);
     }

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterSearchRequestDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterSearchRequestDto.java
@@ -1,12 +1,19 @@
 package com.maple.api.monster.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+@Schema(description = "몬스터 검색 요청 정보")
 public record MonsterSearchRequestDto(
+        @Schema(description = "검색 키워드 (몬스터 이름)", example = "달팽이")
         String keyword,
+        
+        @Schema(description = "최소 레벨", example = "1")
         @Min(1)
         Integer minLevel,
+        
+        @Schema(description = "최대 레벨", example = "200")
         @Max(200)
         Integer maxLevel
 ) {

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
@@ -1,11 +1,20 @@
 package com.maple.api.monster.application.dto;
 
 import com.maple.api.monster.domain.Monster;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "몬스터 요약 정보")
 public record MonsterSummaryDto(
+        @Schema(description = "몬스터 ID", example = "100001")
         Integer monsterId,
+        
+        @Schema(description = "몬스터 이름", example = "달팽이")
         String name,
+        
+        @Schema(description = "몬스터 이미지 URL", example = "https://maplestory.io/api/gms/62/mob/100100/render/stand")
         String imageUrl,
+        
+        @Schema(description = "타입 (고정값: monster)", example = "monster")
         String type
 ) {
     public static MonsterSummaryDto toDto(Monster entity) {

--- a/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
+++ b/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
@@ -3,6 +3,10 @@ package com.maple.api.monster.presentation.restapi;
 import com.maple.api.monster.application.MonsterService;
 import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
 import com.maple.api.monster.application.dto.MonsterSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,14 +21,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/monsters")
 @RequiredArgsConstructor
+@Tag(name = "Monster", description = "몬스터 관련 API")
 public class MonsterController {
 
     private final MonsterService monsterService;
 
     @GetMapping
+    @Operation(
+        summary = "몬스터 검색",
+        description = "다양한 조건으로 몬스터를 검색합니다. 이름으로 필터링할 수 있습니다.\n\n" +
+                     "**정렬 기준:**\n" +
+                     "- monsterId: 몬스터 ID 순 정렬 (기본값)\n" +
+                     "- name, level, exp 등 다양한 필드로 정렬 가능\n\n" +
+                     "**정렬 사용 예시:**\n" +
+                     "- `sort=name,asc` (몬스터 이름 오름차순)\n"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "몬스터 검색 결과 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Page<MonsterSummaryDto>> searchMonsters(
             @Valid @ParameterObject MonsterSearchRequestDto request,
-            @PageableDefault(size = 20, sort = "monsterId") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "monsterId") Pageable pageable) {
         return ResponseEntity.ok(monsterService.searchMonsters(request, pageable));
     }
 }

--- a/src/main/java/com/maple/api/npc/application/dto/NpcSearchRequestDto.java
+++ b/src/main/java/com/maple/api/npc/application/dto/NpcSearchRequestDto.java
@@ -1,6 +1,10 @@
 package com.maple.api.npc.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "NPC 검색 요청 정보")
 public record NpcSearchRequestDto(
+        @Schema(description = "검색 키워드 (NPC 이름)", example = "로저")
         String keyword
 ) {
 }

--- a/src/main/java/com/maple/api/npc/application/dto/NpcSummaryDto.java
+++ b/src/main/java/com/maple/api/npc/application/dto/NpcSummaryDto.java
@@ -1,8 +1,22 @@
 package com.maple.api.npc.application.dto;
 
 import com.maple.api.npc.domain.Npc;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record NpcSummaryDto(Integer npcId, String name, String imageUrl, String type) {
+@Schema(description = "NPC 요약 정보")
+public record NpcSummaryDto(
+        @Schema(description = "NPC ID", example = "2000")
+        Integer npcId,
+        
+        @Schema(description = "NPC 이름", example = "로저")
+        String name,
+        
+        @Schema(description = "NPC 이미지 URL", example = "https://maplestory.io/api/gms/62/npc/2000/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "데이터 타입", example = "npc")
+        String type
+) {
     public static NpcSummaryDto toDto(Npc entity) {
         return new NpcSummaryDto(entity.getNpcId(), entity.getNameKr(), entity.getIconUrlDetail(), "npc");
     }

--- a/src/main/java/com/maple/api/npc/presentation/restapi/NpcController.java
+++ b/src/main/java/com/maple/api/npc/presentation/restapi/NpcController.java
@@ -3,6 +3,10 @@ package com.maple.api.npc.presentation.restapi;
 import com.maple.api.npc.application.NpcService;
 import com.maple.api.npc.application.dto.NpcSearchRequestDto;
 import com.maple.api.npc.application.dto.NpcSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,14 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/npcs")
 @RequiredArgsConstructor
+@Tag(name = "NPC", description = "NPC 관련 API")
 public class NpcController {
 
     private final NpcService npcService;
 
     @GetMapping
+    @Operation(
+        summary = "NPC 검색",
+        description = "다양한 조건으로 NPC를 검색합니다. NPC 이름으로 필터링할 수 있습니다.\n\n" +
+                     "**정렬 기준:**\n" +
+                     "- 기본 정렬 적용\n" +
+                     "- 페이지 크기: 20개 (기본값)"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "NPC 검색 결과 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Page<NpcSummaryDto>> searchNpcs(
             @ParameterObject NpcSearchRequestDto request,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         Page<NpcSummaryDto> npcs = npcService.searchNpcs(request, pageable);
         return ResponseEntity.ok(npcs);
     }

--- a/src/main/java/com/maple/api/quest/application/dto/QuestSearchRequestDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestSearchRequestDto.java
@@ -1,6 +1,10 @@
 package com.maple.api.quest.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀘스트 검색 요청 정보")
 public record QuestSearchRequestDto(
+        @Schema(description = "검색 키워드 (퀘스트 이름)", example = "세라에게")
         String keyword
 ) {
 }

--- a/src/main/java/com/maple/api/quest/application/dto/QuestSummaryDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestSummaryDto.java
@@ -1,8 +1,22 @@
 package com.maple.api.quest.application.dto;
 
 import com.maple.api.quest.domain.Quest;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record QuestSummaryDto(Integer questId, String name, String imageUrl, String type) {
+@Schema(description = "퀘스트 요약 정보")
+public record QuestSummaryDto(
+        @Schema(description = "퀘스트 ID", example = "1000")
+        Integer questId,
+        
+        @Schema(description = "퀘스트 이름", example = "세라에게 거울 빌려오기")
+        String name,
+        
+        @Schema(description = "퀘스트 이미지 URL", example = "https://maplestory.io/api/gms/62/quest/1000/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "데이터 타입 (고정값: 'quest')", example = "quest")
+        String type
+) {
     public static QuestSummaryDto toDto(Quest entity) {
         return new QuestSummaryDto(entity.getQuestId(), entity.getNameKr(), entity.getIconUrl(), "quest");
     }

--- a/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
+++ b/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
@@ -3,6 +3,10 @@ package com.maple.api.quest.presentation.restapi;
 import com.maple.api.quest.application.QuestService;
 import com.maple.api.quest.application.dto.QuestSearchRequestDto;
 import com.maple.api.quest.application.dto.QuestSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,14 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/quests")
 @RequiredArgsConstructor
+@Tag(name = "Quest", description = "퀘스트 관련 API")
 public class QuestController {
 
     private final QuestService questService;
 
     @GetMapping
+    @Operation(
+        summary = "퀘스트 검색",
+        description = "다양한 조건으로 퀘스트를 검색합니다. 퀘스트 이름으로 필터링할 수 있습니다.\n\n" +
+                     "**정렬 기준:**\n" +
+                     "- 기본 정렬 적용\n" +
+                     "- 페이지 크기: 20개 (기본값)"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "퀘스트 검색 결과 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Page<QuestSummaryDto>> searchQuests(
             @ParameterObject QuestSearchRequestDto request,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         Page<QuestSummaryDto> quests = questService.searchQuests(request, pageable);
         return ResponseEntity.ok(quests);
     }

--- a/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
+++ b/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
@@ -1,8 +1,22 @@
 package com.maple.api.search.application.dto;
 
 import com.maple.api.search.domain.VwSearchSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record SearchSummaryDto(Integer originalId, String name, String imageUrl, String type) {
+@Schema(description = "통합 검색 결과 요약 정보")
+public record SearchSummaryDto(
+        @Schema(description = "원본 ID (각 타입별 고유 ID)", example = "1002001")
+        Integer originalId,
+        
+        @Schema(description = "이름", example = "메탈 기어")
+        String name,
+        
+        @Schema(description = "이미지 URL", example = "https://maplestory.io/api/gms/62/item/1002001/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "타입 (ITEM, MONSTER, QUEST, NPC, MAP)", example = "ITEM")
+        String type
+) {
     public static SearchSummaryDto toDto(VwSearchSummary entity) {
         return new SearchSummaryDto(entity.getOriginalId(), entity.getName(), entity.getImageUrl(), entity.getType());
     }

--- a/src/main/java/com/maple/api/search/presentation/restapi/SearchController.java
+++ b/src/main/java/com/maple/api/search/presentation/restapi/SearchController.java
@@ -2,6 +2,11 @@ package com.maple.api.search.presentation.restapi;
 
 import com.maple.api.search.application.SearchService;
 import com.maple.api.search.application.dto.SearchSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,18 +17,40 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springdoc.core.annotations.ParameterObject;
 
 @RestController
 @RequestMapping("/api/v1/search")
 @RequiredArgsConstructor
+@Tag(name = "Search", description = "통합 검색 API")
 public class SearchController {
 
     private final SearchService searchService;
 
     @GetMapping
+    @Operation(
+        summary = "통합 검색",
+        description = "키워드를 이용하여 아이템, 몬스터, 퀘스트, NPC, 맵 등의 정보를 통합적으로 검색합니다. " +
+                     "키워드가 없으면 전체 데이터를 반환합니다.\n\n" +
+                     "**검색 가능한 항목:**\n" +
+                     "- 아이템 (Item)\n" +
+                     "- 몬스터 (Monster)\n" +
+                     "- 퀘스트 (Quest)\n" +
+                     "- NPC\n" +
+                     "- 맵 (Map)\n\n" +
+                     "**정렬 기준:**\n" +
+                     "- name: 이름순 정렬 (기본값)\n" +
+                     "- 페이지 크기: 20개 (기본값)"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 결과 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (키워드 길이 초과 등)"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<Page<SearchSummaryDto>> search(
+            @Parameter(description = "검색할 키워드 (최대 100자)", example = "슬라임")
             @RequestParam(required = false) @Size(max = 100) String keyword,
-            @PageableDefault(size = 20, sort = "name") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable) {
         Page<SearchSummaryDto> results = searchService.search(keyword, pageable);
         return ResponseEntity.ok(results);
     }


### PR DESCRIPTION
## 요약
- ResponseTemplate 제거
- 글로벌 예외 및 커스텀 API 예외 추가
- 스웨거 API 문서 고도화

## 구현 내용 사항
- ResponseTemplate은 진훈님이 래핑되어있지 않은 포맷을 더 선호하셔서 제거했습니다!

## 리뷰 포인트
글로벌 예외를 추가했습니다!

```java
@ExceptionHandler(ApiException.class)
public ResponseEntity<ExceptionResponse> handleApiException(
        ApiException ex, HttpServletRequest request) {
    
    ExceptionResponse exceptionResponse = ExceptionResponse.of(
            ex.getExceptionCode(),
            request.getRequestURI()
    );
    
    log.warn("API exception occurred: {}", ex.getMessage());
    return ResponseEntity.status(ex.getExceptionCode().getStatus()).body(exceptionResponse);
}
```

ApiException은 커스텀 예외입니다.
```java
@Getter
public class ApiException extends RuntimeException {
    
    private final ExceptionCode exceptionCode;

    public ApiException(ExceptionCode exceptionCode) {
        super(exceptionCode.getMessage());
        this.exceptionCode = exceptionCode;
    }

    public ApiException(ExceptionCode exceptionCode, Throwable cause) {
        super(exceptionCode.getMessage(), cause);
        this.exceptionCode = exceptionCode;
    }

    public static ApiException of(ExceptionCode exceptionCode) {
        return new ApiException(exceptionCode);
    }

    public static ApiException of(ExceptionCode exceptionCode, Throwable cause) {
        return new ApiException(exceptionCode, cause);
    }
}
```

```java
@Getter
@RequiredArgsConstructor
public enum GlobalException implements ExceptionCode {

    // 검증 및 파라미터 예외
    VALIDATION_FAILED("입력값 검증에 실패했습니다.", BAD_REQUEST),
    BIND_FAILED("요청 파라미터 바인딩에 실패했습니다.", BAD_REQUEST),
    CONSTRAINT_VIOLATION("제약 조건 위반입니다.", BAD_REQUEST),
    INVALID_ARGUMENT("잘못된 인수입니다.", BAD_REQUEST),
    
    // 404
    RESOURCE_NOT_FOUND("리소스가 존재하지 않습니다.", NOT_FOUND),
    
    // 서버 예외
    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

    private final String message;
    private final HttpStatus status;
}
```

글로벌 예외는 이런 식으로 활용하고, 도메인 별로 예외 enum을 추가하는 방식으로 사용합니다.
```java
@Getter
@RequiredArgsConstructor
public enum ItemException implements ExceptionCode {

    // 아이템 관련 예외
    ITEM_NOT_FOUND("아이템을 찾을 수 없습니다.", NOT_FOUND),
    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다.", NOT_FOUND),
    PARENT_CATEGORY_NOT_FOUND("상위 카테고리를 찾을 수 없습니다.", NOT_FOUND);

    private final String message;
    private final HttpStatus status;
}
```

실제 예외를 던질 때는
```java
throw ApiException.of(ItemException.ITEM_NOT_FOUND);
```
이렇게 활용을 합니다.

그러면 응답은
```json
{
    "message": "아이템을 찾을 수 없습니다.",
    "timestamp": "2025-07-16T21:36:49.403963629",
    "path": "/api/v1/items/20408041"
}
```
이런 식으로 GlobalExceptionHandler가 처리하게 됩니다. 이런 전역 처리 방식에 대해 어떻게 생각하시는 지 궁금합니다!