### PR TITLE
feat: 맵 상세 조회 API 추가

### DIFF
--- a/src/main/java/com/maple/api/map/application/MapService.java
+++ b/src/main/java/com/maple/api/map/application/MapService.java
@@ -1,22 +1,55 @@
 package com.maple.api.map.application;
 
-import com.maple.api.map.application.dto.MapSearchRequestDto;
-import com.maple.api.map.application.dto.MapSummaryDto;
-import com.maple.api.map.repository.MapQueryDslRepository;
+import com.maple.api.common.presentation.exception.ApiException;
+import com.maple.api.map.application.dto.*;
+import com.maple.api.map.exception.MapException;
+import com.maple.api.map.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MapService {
 
     private final MapQueryDslRepository mapQueryDslRepository;
+    private final MapRepository mapRepository;
+    private final MapMonsterQueryDslRepository mapMonsterQueryDslRepository;
+    private final MapNpcQueryDslRepository mapNpcQueryDslRepository;
 
     @Transactional(readOnly = true)
     public Page<MapSummaryDto> searchMaps(MapSearchRequestDto request, Pageable pageable) {
         return mapQueryDslRepository.searchMaps(request, pageable).map(MapSummaryDto::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public MapDetailDto getMapDetail(Integer mapId) {
+        com.maple.api.map.domain.Map map = mapRepository.findById(mapId)
+                .orElseThrow(() -> ApiException.of(MapException.MAP_NOT_FOUND));
+
+        return MapDetailDto.toDto(map);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MapMonsterDto> getMapMonsters(Integer mapId, Sort sort) {
+        if (!mapRepository.existsById(mapId)) {
+            throw ApiException.of(MapException.MAP_NOT_FOUND);
+        }
+
+        return mapMonsterQueryDslRepository.findMapMonsterDtosByMapId(mapId, sort);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MapNpcDto> getMapNpcs(Integer mapId) {
+        if (!mapRepository.existsById(mapId)) {
+            throw ApiException.of(MapException.MAP_NOT_FOUND);
+        }
+
+        return mapNpcQueryDslRepository.findNpcsByMapId(mapId);
     }
 }

--- a/src/main/java/com/maple/api/map/application/dto/MapDetailDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapDetailDto.java
@@ -1,0 +1,44 @@
+package com.maple.api.map.application.dto;
+
+import com.maple.api.map.domain.Map;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "맵 상세 정보")
+public record MapDetailDto(
+        @Schema(description = "맵 ID", example = "100000000")
+        Integer mapId,
+        
+        @Schema(description = "한글명", example = "헤네시스: 헤네시스")
+        String nameKr,
+        
+        @Schema(description = "영문명", example = "Victoria Road: Henesys")
+        String nameEn,
+        
+        @Schema(description = "지역명", example = "헤네시스")
+        String regionName,
+        
+        @Schema(description = "세부 지역명", example = "헤네시스")
+        String detailName,
+        
+        @Schema(description = "최상위 지역명", example = "헤네시스")
+        String topRegionName,
+        
+        @Schema(description = "맵 이미지 URL")
+        String mapUrl,
+        
+        @Schema(description = "아이콘 URL")
+        String iconUrl
+) {
+    public static MapDetailDto toDto(Map map) {
+        return new MapDetailDto(
+                map.getMapId(),
+                map.getNameKr(),
+                map.getNameEn(),
+                map.getRegionName(),
+                map.getDetailName(),
+                map.getTopRegionName(),
+                map.getMapUrl(),
+                map.getIconUrl()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/map/application/dto/MapMonsterDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapMonsterDto.java
@@ -1,0 +1,33 @@
+package com.maple.api.map.application.dto;
+
+import com.maple.api.map.domain.MonsterSpawnMap;
+import com.maple.api.monster.domain.Monster;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "맵 출현 몬스터 정보")
+public record MapMonsterDto(
+        @Schema(description = "몬스터 ID", example = "3210800")
+        Integer monsterId,
+        
+        @Schema(description = "몬스터 이름", example = "루팡")
+        String monsterName,
+        
+        @Schema(description = "몬스터 레벨", example = "37")
+        Integer level,
+        
+        @Schema(description = "최대 스폰 수", example = "20")
+        Integer maxSpawnCount,
+        
+        @Schema(description = "몬스터 이미지 URL")
+        String imageUrl
+) {
+    public static MapMonsterDto toDto(MonsterSpawnMap spawnMap, Monster monster) {
+        return new MapMonsterDto(
+                monster.getMonsterId(),
+                monster.getNameKr(),
+                monster.getLevel(),
+                spawnMap.getMaxSpawnCount(),
+                monster.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/map/application/dto/MapNpcDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapNpcDto.java
@@ -1,0 +1,28 @@
+package com.maple.api.map.application.dto;
+
+import com.maple.api.npc.domain.Npc;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "맵 출현 NPC 정보")
+public record MapNpcDto(
+        @Schema(description = "NPC ID", example = "1010100")
+        Integer npcId,
+        
+        @Schema(description = "NPC 이름", example = "리나")
+        String npcName,
+        
+        @Schema(description = "영문명", example = "Rina")
+        String npcNameEn,
+        
+        @Schema(description = "NPC 아이콘 URL")
+        String iconUrl
+) {
+    public static MapNpcDto toDto(Npc npc) {
+        return new MapNpcDto(
+                npc.getNpcId(),
+                npc.getNameKr(),
+                npc.getNameEn(),
+                npc.getIconUrlDetail()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/map/exception/MapException.java
+++ b/src/main/java/com/maple/api/map/exception/MapException.java
@@ -1,0 +1,18 @@
+package com.maple.api.map.exception;
+
+import com.maple.api.common.presentation.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum MapException implements ExceptionCode {
+
+    MAP_NOT_FOUND("존재하지 않는 맵입니다.", NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
+++ b/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
@@ -1,8 +1,8 @@
 package com.maple.api.map.presentation.restapi;
 
 import com.maple.api.map.application.MapService;
-import com.maple.api.map.application.dto.MapSearchRequestDto;
-import com.maple.api.map.application.dto.MapSummaryDto;
+import com.maple.api.map.application.dto.*;
+import org.springframework.data.domain.Sort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -12,10 +12,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/maps")
@@ -43,5 +43,58 @@ public class MapController {
             @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         Page<MapSummaryDto> maps = mapService.searchMaps(request, pageable);
         return ResponseEntity.ok(maps);
+    }
+
+    @GetMapping("/{mapId}")
+    @Operation(
+        summary = "맵 상세 조회",
+        description = "특정 맵의 상세 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "맵 상세 정보 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 맵"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<MapDetailDto> getMapDetail(@PathVariable Integer mapId) {
+        MapDetailDto mapDetail = mapService.getMapDetail(mapId);
+        return ResponseEntity.ok(mapDetail);
+    }
+
+    @GetMapping("/{mapId}/monsters")
+    @Operation(
+        summary = "맵 몬스터 리스트 조회",
+        description = "특정 맵에서 출현하는 몬스터 리스트를 조회합니다.\n\n" +
+                     "**정렬 옵션:**\n" +
+                     "- `level`: 몬스터 레벨 기준\n" +
+                     "- `maxSpawnCount`: 최대 스폰 수 기준\n\n" +
+                     "**사용 예시:**\n" +
+                     "- `?sort=level,desc`: 레벨 내림차순\n" +
+                     "- `?sort=maxSpawnCount,asc`: 스폰 수 오름차순"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "몬스터 리스트 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 맵"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<List<MapMonsterDto>> getMapMonsters(
+            @PathVariable Integer mapId,
+            @ParameterObject Sort sort) {
+        List<MapMonsterDto> monsters = mapService.getMapMonsters(mapId, sort);
+        return ResponseEntity.ok(monsters);
+    }
+
+    @GetMapping("/{mapId}/npcs")
+    @Operation(
+        summary = "맵 NPC 리스트 조회",
+        description = "특정 맵에 있는 NPC 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "NPC 리스트 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 맵"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<List<MapNpcDto>> getMapNpcs(@PathVariable Integer mapId) {
+        List<MapNpcDto> npcs = mapService.getMapNpcs(mapId);
+        return ResponseEntity.ok(npcs);
     }
 }

--- a/src/main/java/com/maple/api/map/repository/MapMonsterQueryDslRepository.java
+++ b/src/main/java/com/maple/api/map/repository/MapMonsterQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.maple.api.map.repository;
+
+import com.maple.api.map.application.dto.MapMonsterDto;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public interface MapMonsterQueryDslRepository {
+    List<MapMonsterDto> findMapMonsterDtosByMapId(Integer mapId, Sort sort);
+}

--- a/src/main/java/com/maple/api/map/repository/MapMonsterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/map/repository/MapMonsterQueryDslRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.maple.api.map.repository;
+
+import com.maple.api.map.application.dto.MapMonsterDto;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.maple.api.map.domain.QMonsterSpawnMap.monsterSpawnMap;
+import static com.maple.api.monster.domain.QMonster.monster;
+
+@Repository
+@RequiredArgsConstructor
+public class MapMonsterQueryDslRepositoryImpl implements MapMonsterQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+    
+    private final Map<String, Path<?>> sortableProperties = Map.of(
+            "level", monster.level,
+            "maxSpawnCount", monsterSpawnMap.maxSpawnCount,
+            "monsterId", monster.monsterId
+    );
+
+    @Override
+    public List<MapMonsterDto> findMapMonsterDtosByMapId(Integer mapId, Sort sort) {
+        List<OrderSpecifier<?>> orderClause = createOrderClause(sort);
+        
+        List<Tuple> tuples = queryFactory
+                .select(monster.monsterId,
+                        monster.nameKr,
+                        monster.level,
+                        monsterSpawnMap.maxSpawnCount,
+                        monster.imageUrl)
+                .from(monsterSpawnMap)
+                .join(monster).on(monsterSpawnMap.monsterId.eq(monster.monsterId))
+                .where(monsterSpawnMap.mapId.eq(mapId))
+                .orderBy(orderClause.toArray(new OrderSpecifier[0]))
+                .fetch();
+        
+        return tuples.stream()
+                .map(tuple -> new MapMonsterDto(
+                        tuple.get(monster.monsterId),
+                        tuple.get(monster.nameKr),
+                        tuple.get(monster.level),
+                        tuple.get(monsterSpawnMap.maxSpawnCount),
+                        tuple.get(monster.imageUrl)
+                ))
+                .toList();
+    }
+
+    private List<OrderSpecifier<?>> createOrderClause(Sort sort) {
+        if (sort.isUnsorted()) {
+            return List.of(monster.monsterId.asc());
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        sort.forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path));
+            }
+        });
+
+        // 기본 정렬 추가 (일관된 결과를 위해)
+        orderSpecifiers.add(monster.monsterId.asc());
+        return orderSpecifiers;
+    }
+}

--- a/src/main/java/com/maple/api/map/repository/MapNpcQueryDslRepository.java
+++ b/src/main/java/com/maple/api/map/repository/MapNpcQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.maple.api.map.repository;
+
+import com.maple.api.map.application.dto.MapNpcDto;
+
+import java.util.List;
+
+public interface MapNpcQueryDslRepository {
+    List<MapNpcDto> findNpcsByMapId(Integer mapId);
+}

--- a/src/main/java/com/maple/api/map/repository/MapNpcQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/map/repository/MapNpcQueryDslRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.maple.api.map.repository;
+
+import com.maple.api.map.application.dto.MapNpcDto;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.maple.api.map.domain.QMapNpc.mapNpc;
+import static com.maple.api.npc.domain.QNpc.npc;
+
+@Repository
+@RequiredArgsConstructor
+public class MapNpcQueryDslRepositoryImpl implements MapNpcQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MapNpcDto> findNpcsByMapId(Integer mapId) {
+        List<Tuple> tuples = queryFactory
+                .select(npc.npcId,
+                        npc.nameKr,
+                        npc.nameEn,
+                        npc.iconUrlDetail)
+                .from(mapNpc)
+                .join(npc).on(mapNpc.npcId.eq(npc.npcId))
+                .where(mapNpc.mapId.eq(mapId))
+                .orderBy(npc.npcId.asc()) // 일관된 결과를 위한 기본 정렬
+                .fetch();
+        
+        return tuples.stream()
+                .map(tuple -> new MapNpcDto(
+                        tuple.get(npc.npcId),
+                        tuple.get(npc.nameKr),
+                        tuple.get(npc.nameEn),
+                        tuple.get(npc.iconUrlDetail)
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
### 요약
몬스터 상세 조회 API를 만들었습니다.

## 구현 내용 사항
- 몬스터 상세 조회 API
- 맵 스폰 몬스터 조회 API
- 맵 NPC 조회 API

### 맵 상세 조회 API 예시 `/api/v1/maps/100040101`
```java
{
    "mapId": 100040101,
    "nameKr": "히든스트리트: 원숭이의숲1",
    "nameEn": "Hidden Street: Monkey Forest I",
    "regionName": "히든스트리트",
    "detailName": "원숭이의숲1",
    "topRegionName": "엘리니아",
    "mapUrl": "https://maplestory.io/api/gms/62/map/100040101/render?resize=2",
    "iconUrl": "https://maplestory.io/api/gms/62/map/100040101/icon?resize=2"
}
```

### 맵 스폰 몬스터 조회 API 예시 /api/v1/maps/100040101/monsters
```java
[
    {
        "monsterId": 3210800,
        "monsterName": "루팡",
        "level": 37,
        "maxSpawnCount": 20,
        "imageUrl": "https://maplestory.io/api/gms/62/mob/3210800/render/stand"
    },
    {
        "monsterId": 4230101,
        "monsterName": "좀비루팡",
        "level": 40,
        "maxSpawnCount": 26,
        "imageUrl": "https://maplestory.io/api/gms/62/mob/4230101/render/stand"
    }
]
```

###  맵 NPC 조회 API 예시 /api/v1/maps/100000100/npcs
```java
[
    {
        "npcId": 1012002,
        "npcName": "비셔스",
        "npcNameEn": "Vicious",
        "iconUrl": "https://maplestory.io/api/gms/62/npc/1012002/icon?resize=2"
    },
    {
        "npcId": 1012004,
        "npcName": "큐트",
        "npcNameEn": "Doofus",
        "iconUrl": "https://maplestory.io/api/gms/62/npc/1012004/icon?resize=2"
    }
]
```

### 리뷰 포인트
이번에 맵 상세 조회 기능에 사용할 API를 총 3개 만들었습니다.

아이템 상세 조회, 몬스터 상세 조회와 달리 이번에 3개나 만든 이유는,,, 사실 제가 기획을 누락했기 때문입니다 ㅠ ㅠ

아이템 상세 조회에서는 아예 드롭 몬스터를 누락했고,
몬스터 상세 조회에서는 스폰 맵과 드롭 아이템을 추가는 했지만 정렬 기능을 누락했습니다. ㅠ ㅠ 죄송합니다...

이번에는 다행히도 기획에서 정렬 기능이 필요하다는걸 알게되었는데, 맵 상세 조회 API에 몬스터의 sort를 넣는다는 것이 좀 어색했습니다. 또 만약에 NPC에 대한 정렬까지 생긴다면 코드가 되게 복잡해지겠다는 생각도 들어서 저번과는 달리 API를 나눠봤습니다.

API 하나에 스폰 몬스터, NPC 조회를 다 담는 것보다 따로 나누는게 API 자체가 의미하는 것도 더 명확하고, 구현도 더 편하고, 또 확장성도 높을 것 같더라구요

이 부분에 대해서 어떻게 생각하실지 궁금합니다! 만약에 괜찮다면 아이템 상세 조회와 몬스터 상세 조회도 API를 나누는 방식으로 수정할 예정입니다!