### PR TITLE
아이템 드롭 몬스터 리스트 조회 API

### DIFF
--- a/src/main/java/com/maple/api/item/application/ItemService.java
+++ b/src/main/java/com/maple/api/item/application/ItemService.java
@@ -2,6 +2,7 @@ package com.maple.api.item.application;
 
 import com.maple.api.common.presentation.exception.ApiException;
 import com.maple.api.item.application.dto.ItemDetailDto;
+import com.maple.api.item.application.dto.ItemMonsterDropDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.application.dto.ItemSummaryDto;
 import com.maple.api.item.domain.Category;
@@ -16,6 +17,7 @@ import com.maple.api.job.repository.JobRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +64,15 @@ public class ItemService {
         } else {
             return item;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ItemMonsterDropDto> getItemDropMonsters(Integer itemId, Sort sort) {
+        if (!itemRepository.existsById(itemId)) {
+            throw ApiException.of(ItemException.ITEM_NOT_FOUND);
+        }
+
+        return itemQueryDslRepository.findItemDropMonstersByItemId(itemId, sort);
     }
 
 }

--- a/src/main/java/com/maple/api/item/application/dto/ItemMonsterDropDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemMonsterDropDto.java
@@ -1,0 +1,22 @@
+package com.maple.api.item.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "아이템을 드롭하는 몬스터 정보")
+public record ItemMonsterDropDto(
+        @Schema(description = "몬스터 ID", example = "7220001")
+        Integer monsterId,
+        
+        @Schema(description = "몬스터 이름", example = "구미호")
+        String monsterName,
+        
+        @Schema(description = "몬스터 레벨", example = "70")
+        Integer level,
+        
+        @Schema(description = "드롭율", example = "0.1")
+        Double dropRate,
+        
+        @Schema(description = "몬스터 이미지 URL")
+        String imageUrl
+) {
+}

--- a/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
+++ b/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
@@ -2,22 +2,28 @@ package com.maple.api.item.presentation.restapi;
 
 import com.maple.api.item.application.ItemService;
 import com.maple.api.item.application.dto.ItemDetailDto;
+import com.maple.api.item.application.dto.ItemMonsterDropDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.application.dto.ItemSummaryDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/items")
@@ -60,5 +66,31 @@ public class ItemController {
             @PathVariable Integer id) {
         ItemDetailDto itemDetail = itemService.getItemDetail(id);
         return ResponseEntity.ok(itemDetail);
+    }
+
+    @GetMapping("/{itemId}/monsters")
+    @Operation(
+        summary = "아이템 드롭 몬스터 리스트 조회",
+        description = "특정 아이템을 드롭하는 몬스터 리스트를 조회합니다.\n\n" +
+                     "**정렬 옵션:**\n" +
+                     "- `dropRate`: 드롭율 기준\n" +
+                     "- `level`: 몬스터 레벨 기준\n" +
+                     "- `monsterId`: 몬스터 ID 기준\n\n" +
+                     "**사용 예시:**\n" +
+                     "- `?sort=dropRate,desc`: 드롭율 내림차순\n" +
+                     "- `?sort=level,asc`: 레벨 오름차순\n" +
+                     "- `?sort=level,desc`: 레벨 내림차순"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "드롭 몬스터 리스트 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 아이템"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<List<ItemMonsterDropDto>> getItemDropMonsters(
+            @Parameter(description = "아이템 ID", example = "2070005", required = true)
+            @PathVariable Integer itemId,
+            @ParameterObject Sort sort) {
+        List<ItemMonsterDropDto> dropMonsters = itemService.getItemDropMonsters(itemId, sort);
+        return ResponseEntity.ok(dropMonsters);
     }
 }

--- a/src/main/java/com/maple/api/item/repository/ItemQueryDslRepository.java
+++ b/src/main/java/com/maple/api/item/repository/ItemQueryDslRepository.java
@@ -1,10 +1,15 @@
 package com.maple.api.item.repository;
 
+import com.maple.api.item.application.dto.ItemMonsterDropDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.domain.Item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 public interface ItemQueryDslRepository {
     Page<Item> searchItems(ItemSearchRequestDto searchRequest, Pageable pageable);
+    List<ItemMonsterDropDto> findItemDropMonstersByItemId(Integer itemId, Sort sort);
 }


### PR DESCRIPTION
누락된 아이템의 드롭 몬스터 리스트 조회하는 API 추가.

**정렬 옵션**
- `dropRate`: 드롭율 기준
- `level`: 몬스터 레벨 기준
- `monsterId`: 몬스터 ID 기준