### PR TITLE
퀘스트 상세 조회 API

### DIFF
--- a/src/main/java/com/maple/api/quest/application/QuestService.java
+++ b/src/main/java/com/maple/api/quest/application/QuestService.java
@@ -1,24 +1,147 @@
 package com.maple.api.quest.application;
 
-import com.maple.api.quest.application.dto.QuestSearchRequestDto;
-import com.maple.api.quest.application.dto.QuestSummaryDto;
-import com.maple.api.quest.domain.Quest;
-import com.maple.api.quest.repository.QuestQueryDslRepository;
+import com.maple.api.item.domain.Item;
+import com.maple.api.item.repository.ItemRepository;
+import com.maple.api.job.domain.Job;
+import com.maple.api.job.repository.JobRepository;
+import com.maple.api.monster.domain.Monster;
+import com.maple.api.monster.repository.MonsterRepository;
+import com.maple.api.quest.application.dto.*;
+import com.maple.api.quest.domain.*;
+import com.maple.api.common.presentation.exception.ApiException;
+import com.maple.api.quest.exception.QuestException;
+import com.maple.api.quest.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class QuestService {
 
     private final QuestQueryDslRepository questQueryDslRepository;
+    private final QuestRepository questRepository;
+    private final QuestRewardRepository questRewardRepository;
+    private final QuestRewardItemRepository questRewardItemRepository;
+    private final QuestRequirementRepository questRequirementRepository;
+    private final QuestAllowedJobRepository questAllowedJobRepository;
+    private final ItemRepository itemRepository;
+    private final MonsterRepository monsterRepository;
+    private final JobRepository jobRepository;
 
     @Transactional(readOnly = true)
     public Page<QuestSummaryDto> searchQuests(QuestSearchRequestDto request, Pageable pageable) {
         Page<Quest> questPage = questQueryDslRepository.searchQuests(request, pageable);
         return questPage.map(QuestSummaryDto::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public QuestDetailDto getQuestDetail(Integer questId) {
+        Quest quest = findQuest(questId);
+        
+        QuestReward reward = findQuestReward(questId);
+        List<QuestRewardItem> rewardItems = findQuestRewardItems(questId);
+        List<QuestRequirement> requirements = findQuestRequirements(questId);
+        List<QuestAllowedJob> allowedJobs = findQuestAllowedJobs(questId);
+
+        Map<Integer, String> itemNameMap = fetchItemNames(rewardItems, requirements);
+        Map<Integer, String> monsterNameMap = fetchMonsterNames(requirements);
+        Map<Integer, String> jobNameMap = fetchJobNames(allowedJobs);
+
+        return buildQuestDetailDto(quest, reward, rewardItems, requirements, allowedJobs, 
+                                 itemNameMap, monsterNameMap, jobNameMap);
+    }
+
+    private Quest findQuest(Integer questId) {
+        return questRepository.findById(questId)
+                .orElseThrow(() -> ApiException.of(QuestException.QUEST_NOT_FOUND));
+    }
+
+    private QuestReward findQuestReward(Integer questId) {
+        return questRewardRepository.findByQuestId(questId).orElse(null);
+    }
+
+    private List<QuestRewardItem> findQuestRewardItems(Integer questId) {
+        return questRewardItemRepository.findByQuestId(questId);
+    }
+
+    private List<QuestRequirement> findQuestRequirements(Integer questId) {
+        return questRequirementRepository.findByQuestId(questId);
+    }
+
+    private List<QuestAllowedJob> findQuestAllowedJobs(Integer questId) {
+        return questAllowedJobRepository.findByQuestId(questId);
+    }
+
+    private Map<Integer, String> fetchItemNames(List<QuestRewardItem> rewardItems, List<QuestRequirement> requirements) {
+        List<Integer> itemIds = rewardItems.stream()
+                .map(QuestRewardItem::getItemId)
+                .distinct()
+                .collect(Collectors.toList());
+        
+        List<Integer> requirementItemIds = requirements.stream()
+                .map(QuestRequirement::getItemId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        
+        itemIds.addAll(requirementItemIds);
+        
+        return itemRepository.findByItemIdIn(itemIds.stream().distinct().collect(Collectors.toList()))
+                .stream()
+                .collect(Collectors.toMap(Item::getItemId, Item::getNameKr));
+    }
+
+    private Map<Integer, String> fetchMonsterNames(List<QuestRequirement> requirements) {
+        List<Integer> monsterIds = requirements.stream()
+                .filter(req -> req.getMonsterId() != null)
+                .map(QuestRequirement::getMonsterId)
+                .distinct()
+                .collect(Collectors.toList());
+        
+        return monsterRepository.findAllById(monsterIds)
+                .stream()
+                .collect(Collectors.toMap(Monster::getMonsterId, Monster::getNameKr));
+    }
+
+    private Map<Integer, String> fetchJobNames(List<QuestAllowedJob> allowedJobs) {
+        List<Integer> jobIds = allowedJobs.stream()
+                .map(QuestAllowedJob::getJobId)
+                .distinct()
+                .collect(Collectors.toList());
+        
+        return jobRepository.findAllById(jobIds)
+                .stream()
+                .collect(Collectors.toMap(Job::getJobId, Job::getJobName));
+    }
+
+    private QuestDetailDto buildQuestDetailDto(Quest quest, QuestReward reward, 
+                                             List<QuestRewardItem> rewardItems, List<QuestRequirement> requirements,
+                                             List<QuestAllowedJob> allowedJobs, Map<Integer, String> itemNameMap,
+                                             Map<Integer, String> monsterNameMap, Map<Integer, String> jobNameMap) {
+        QuestRewardDto rewardDto = reward != null ? QuestRewardDto.toDto(reward) : null;
+
+        List<QuestRewardItemDto> rewardItemDtos = rewardItems.stream()
+                .map(item -> QuestRewardItemDto.toDto(item, itemNameMap.get(item.getItemId())))
+                .collect(Collectors.toList());
+
+        List<QuestRequirementDto> requirementDtos = requirements.stream()
+                .map(req -> QuestRequirementDto.toDto(req, 
+                        req.getItemId() != null ? itemNameMap.get(req.getItemId()) : null,
+                        req.getMonsterId() != null ? monsterNameMap.get(req.getMonsterId()) : null))
+                .collect(Collectors.toList());
+
+        List<QuestJobDto> allowedJobDtos = allowedJobs.stream()
+                .map(job -> new QuestJobDto(job.getJobId(), jobNameMap.get(job.getJobId())))
+                .collect(Collectors.toList());
+
+        return QuestDetailDto.toDto(quest, rewardDto, rewardItemDtos, requirementDtos, allowedJobDtos);
     }
 }

--- a/src/main/java/com/maple/api/quest/application/dto/QuestChainDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestChainDto.java
@@ -1,0 +1,32 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.quest.domain.Quest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "연계 퀘스트 정보")
+public record QuestChainDto(
+        @Schema(description = "퀘스트 ID", example = "1001")
+        Integer questId,
+        
+        @Schema(description = "퀘스트 이름", example = "히나에게 거울 가져가기")
+        String name,
+        
+        @Schema(description = "퀘스트 수락 최소 레벨", example = "0")
+        Integer minLevel,
+        
+        @Schema(description = "퀘스트 수락 최대 레벨", example = "null")
+        Integer maxLevel,
+        
+        @Schema(description = "퀘스트 아이콘 URL", example = "https://maplestory.io/api/gms/62/quest/1001/icon?resize=2")
+        String iconUrl
+) {
+    public static QuestChainDto toDto(Quest quest) {
+        return new QuestChainDto(
+                quest.getQuestId(),
+                quest.getNameKr(),
+                quest.getMinLevel(),
+                quest.getMaxLevel(),
+                quest.getIconUrl()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestChainResponseDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestChainResponseDto.java
@@ -1,0 +1,18 @@
+package com.maple.api.quest.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "연계 퀘스트 조회 응답")
+public record QuestChainResponseDto(
+        @Schema(description = "선행 완료 퀘스트 목록")
+        List<QuestChainDto> previousQuests,
+        
+        @Schema(description = "퀘스트 완료 시 열리는 퀘스트 목록")
+        List<QuestChainDto> nextQuests
+) {
+    public static QuestChainResponseDto of(List<QuestChainDto> previousQuests, List<QuestChainDto> nextQuests) {
+        return new QuestChainResponseDto(previousQuests, nextQuests);
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
@@ -37,8 +37,14 @@ public record QuestDetailDto(
         @Schema(description = "시작 NPC ID", example = "2060005")
         Long startNpcId,
         
+        @Schema(description = "시작 NPC 이름", example = "이벤트 안내")
+        String startNpcName,
+        
         @Schema(description = "완료 NPC ID", example = "2060005")
         Long endNpcId,
+        
+        @Schema(description = "완료 NPC 이름", example = "이벤트 안내")
+        String endNpcName,
         
         @Schema(description = "퀘스트 보상 정보")
         QuestRewardDto reward,
@@ -53,7 +59,8 @@ public record QuestDetailDto(
         List<QuestJobDto> allowedJobs
 ) {
     public static QuestDetailDto toDto(Quest quest, QuestRewardDto reward, List<QuestRewardItemDto> rewardItems, 
-                                      List<QuestRequirementDto> requirements, List<QuestJobDto> allowedJobs) {
+                                      List<QuestRequirementDto> requirements, List<QuestJobDto> allowedJobs,
+                                      String startNpcName, String endNpcName) {
         return new QuestDetailDto(
                 quest.getQuestId(),
                 quest.getTitlePrefix(),
@@ -65,7 +72,9 @@ public record QuestDetailDto(
                 quest.getMaxLevel(),
                 quest.getRequiredMesoStart(),
                 quest.getStartNpcId(),
+                startNpcName,
                 quest.getEndNpcId(),
+                endNpcName,
                 reward,
                 rewardItems,
                 requirements,

--- a/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
@@ -1,0 +1,75 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.quest.domain.Quest;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "퀘스트 상세 정보 DTO")
+public record QuestDetailDto(
+        @Schema(description = "퀘스트 ID", example = "6002")
+        Integer questId,
+        
+        @Schema(description = "퀘스트 타이틀 접두사", example = "[체험]")
+        String titlePrefix,
+        
+        @Schema(description = "퀘스트명 (한국어)", example = "몬스터 라이딩")
+        String nameKr,
+        
+        @Schema(description = "퀘스트명 (영어)", example = "Monster Riding")
+        String nameEn,
+        
+        @Schema(description = "퀘스트 아이콘 URL", example = "https://maplestory.io/api/gms/62/quest/6002/icon?resize=2")
+        String iconUrl,
+        
+        @Schema(description = "퀘스트 타입", example = "1회성")
+        String questType,
+        
+        @Schema(description = "최소 레벨", example = "70")
+        Integer minLevel,
+        
+        @Schema(description = "최대 레벨", example = "null")
+        Integer maxLevel,
+        
+        @Schema(description = "시작 시 필요한 메소", example = "0")
+        Integer requiredMesoStart,
+        
+        @Schema(description = "시작 NPC ID", example = "2060005")
+        Long startNpcId,
+        
+        @Schema(description = "완료 NPC ID", example = "2060005")
+        Long endNpcId,
+        
+        @Schema(description = "퀘스트 보상 정보")
+        QuestRewardDto reward,
+        
+        @Schema(description = "퀘스트 보상 아이템 목록")
+        List<QuestRewardItemDto> rewardItems,
+        
+        @Schema(description = "퀘스트 완료 조건 목록")
+        List<QuestRequirementDto> requirements,
+        
+        @Schema(description = "허용 직업 목록")
+        List<QuestJobDto> allowedJobs
+) {
+    public static QuestDetailDto toDto(Quest quest, QuestRewardDto reward, List<QuestRewardItemDto> rewardItems, 
+                                      List<QuestRequirementDto> requirements, List<QuestJobDto> allowedJobs) {
+        return new QuestDetailDto(
+                quest.getQuestId(),
+                quest.getTitlePrefix(),
+                quest.getNameKr(),
+                quest.getNameEn(),
+                quest.getIconUrl(),
+                quest.getQuestType(),
+                quest.getMinLevel(),
+                quest.getMaxLevel(),
+                quest.getRequiredMesoStart(),
+                quest.getStartNpcId(),
+                quest.getEndNpcId(),
+                reward,
+                rewardItems,
+                requirements,
+                allowedJobs
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestJobDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestJobDto.java
@@ -1,0 +1,20 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.job.domain.Job;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀘스트 허용 직업 DTO")
+public record QuestJobDto(
+        @Schema(description = "직업 ID", example = "100")
+        Integer jobId,
+        
+        @Schema(description = "직업명", example = "전사")
+        String jobName
+) {
+    public static QuestJobDto toDto(Job job) {
+        return new QuestJobDto(
+                job.getJobId(),
+                job.getJobName()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestRequirementDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestRequirementDto.java
@@ -1,0 +1,36 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.quest.domain.QuestRequirement;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀘스트 완료 조건 DTO")
+public record QuestRequirementDto(
+        @Schema(description = "완료 조건 타입(item, monster)", example = "item")
+        String requirementType,
+        
+        @Schema(description = "아이템 ID", example = "4031507")
+        Integer itemId,
+        
+        @Schema(description = "아이템명", example = "페로몬")
+        String itemName,
+        
+        @Schema(description = "몬스터 ID", example = "null")
+        Integer monsterId,
+        
+        @Schema(description = "몬스터명", example = "null")
+        String monsterName,
+        
+        @Schema(description = "수량", example = "5")
+        Integer quantity
+) {
+    public static QuestRequirementDto toDto(QuestRequirement requirement, String itemName, String monsterName) {
+        return new QuestRequirementDto(
+                requirement.getRequirementType(),
+                requirement.getItemId(),
+                itemName,
+                requirement.getMonsterId(),
+                monsterName,
+                requirement.getQuantity()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestRewardDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestRewardDto.java
@@ -1,0 +1,24 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.quest.domain.QuestReward;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀘스트 보상 정보 DTO")
+public record QuestRewardDto(
+        @Schema(description = "경험치", example = "1000")
+        Long exp,
+        
+        @Schema(description = "메소", example = "5000")
+        Long meso,
+        
+        @Schema(description = "인기도", example = "10")
+        Integer popularity
+) {
+    public static QuestRewardDto toDto(QuestReward reward) {
+        return new QuestRewardDto(
+                reward.getExp(),
+                reward.getMeso(),
+                reward.getPopularity()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/application/dto/QuestRewardItemDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestRewardItemDto.java
@@ -1,0 +1,24 @@
+package com.maple.api.quest.application.dto;
+
+import com.maple.api.quest.domain.QuestRewardItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀘스트 보상 아이템 DTO")
+public record QuestRewardItemDto(
+        @Schema(description = "아이템 ID", example = "1912000")
+        Integer itemId,
+        
+        @Schema(description = "아이템명", example = "안장")
+        String itemName,
+        
+        @Schema(description = "수량", example = "1")
+        Integer quantity
+) {
+    public static QuestRewardItemDto toDto(QuestRewardItem item, String itemName) {
+        return new QuestRewardItemDto(
+                item.getItemId(),
+                itemName,
+                item.getQuantity()
+        );
+    }
+}

--- a/src/main/java/com/maple/api/quest/domain/QuestAllowedJob.java
+++ b/src/main/java/com/maple/api/quest/domain/QuestAllowedJob.java
@@ -13,10 +13,9 @@ public class QuestAllowedJob extends BaseEntity {
     @Id
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "quest_id")
-    private Quest quest;
+    @Column(name = "quest_id")
+    private Integer questId;
 
-    @Column(name = "job_name")
-    private String jobName;
+    @Column(name = "job_id")
+    private Integer jobId;
 }

--- a/src/main/java/com/maple/api/quest/domain/QuestChainMember.java
+++ b/src/main/java/com/maple/api/quest/domain/QuestChainMember.java
@@ -13,13 +13,11 @@ public class QuestChainMember extends BaseEntity {
     @Id
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chain_id")
-    private QuestChain chain;
+    @Column(name = "chain_id")
+    private Integer chainId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "quest_id")
-    private Quest quest;
+    @Column(name = "quest_id")
+    private Integer questId;
 
     @Column(name = "sequence_order")
     private Integer sequenceOrder;

--- a/src/main/java/com/maple/api/quest/exception/QuestException.java
+++ b/src/main/java/com/maple/api/quest/exception/QuestException.java
@@ -1,0 +1,16 @@
+package com.maple.api.quest.exception;
+
+import com.maple.api.common.presentation.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestException implements ExceptionCode {
+
+    QUEST_NOT_FOUND("퀘스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
+++ b/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
@@ -1,6 +1,7 @@
 package com.maple.api.quest.presentation.restapi;
 
 import com.maple.api.quest.application.QuestService;
+import com.maple.api.quest.application.dto.QuestDetailDto;
 import com.maple.api.quest.application.dto.QuestSearchRequestDto;
 import com.maple.api.quest.application.dto.QuestSummaryDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +45,20 @@ public class QuestController {
             @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
         Page<QuestSummaryDto> quests = questService.searchQuests(request, pageable);
         return ResponseEntity.ok(quests);
+    }
+
+    @GetMapping("/{questId}")
+    @Operation(
+        summary = "퀘스트 상세 조회",
+        description = "퀘스트의 상세 정보를 조회합니다. 퀘스트 기본 정보, 보상, 완료 조건, 허용 직업 등의 정보를 포함합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "퀘스트 상세 정보 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "퀘스트를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<QuestDetailDto> getQuestDetail(@PathVariable Integer questId) {
+        QuestDetailDto questDetail = questService.getQuestDetail(questId);
+        return ResponseEntity.ok(questDetail);
     }
 }

--- a/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
+++ b/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
@@ -1,6 +1,7 @@
 package com.maple.api.quest.presentation.restapi;
 
 import com.maple.api.quest.application.QuestService;
+import com.maple.api.quest.application.dto.QuestChainResponseDto;
 import com.maple.api.quest.application.dto.QuestDetailDto;
 import com.maple.api.quest.application.dto.QuestSearchRequestDto;
 import com.maple.api.quest.application.dto.QuestSummaryDto;
@@ -60,5 +61,21 @@ public class QuestController {
     public ResponseEntity<QuestDetailDto> getQuestDetail(@PathVariable Integer questId) {
         QuestDetailDto questDetail = questService.getQuestDetail(questId);
         return ResponseEntity.ok(questDetail);
+    }
+
+    @GetMapping("/{questId}/chain")
+    @Operation(
+        summary = "연계 퀘스트 조회",
+        description = "특정 퀘스트의 연계 퀘스트 정보를 조회합니다. " +
+                     "선행 완료 퀘스트와 퀘스트 완료 시 열리는 퀘스트 목록을 제공합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연계 퀘스트 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "퀘스트를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<QuestChainResponseDto> getQuestChain(@PathVariable Integer questId) {
+        QuestChainResponseDto questChain = questService.getQuestChain(questId);
+        return ResponseEntity.ok(questChain);
     }
 }

--- a/src/main/java/com/maple/api/quest/repository/QuestAllowedJobRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestAllowedJobRepository.java
@@ -1,0 +1,12 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestAllowedJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestAllowedJobRepository extends JpaRepository<QuestAllowedJob, Integer> {
+    List<QuestAllowedJob> findByQuestId(Integer questId);
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestChainMemberRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestChainMemberRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface QuestChainMemberRepository extends JpaRepository<QuestChainMember, Integer> {
     Optional<QuestChainMember> findByQuestId(Integer questId);
-    List<QuestChainMember> findByChainIdOrderBySequenceOrder(Integer chainId);
+    List<QuestChainMember> findByChainId(Integer chainId);
 }

--- a/src/main/java/com/maple/api/quest/repository/QuestChainMemberRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestChainMemberRepository.java
@@ -1,0 +1,14 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestChainMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface QuestChainMemberRepository extends JpaRepository<QuestChainMember, Integer> {
+    Optional<QuestChainMember> findByQuestId(Integer questId);
+    List<QuestChainMember> findByChainIdOrderBySequenceOrder(Integer chainId);
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestChainRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestChainRepository.java
@@ -1,0 +1,9 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestChain;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestChainRepository extends JpaRepository<QuestChain, Integer> {
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestRepository.java
@@ -1,0 +1,9 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.Quest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestRepository extends JpaRepository<Quest, Integer> {
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestRequirementRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestRequirementRepository.java
@@ -1,0 +1,12 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestRequirement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestRequirementRepository extends JpaRepository<QuestRequirement, Integer> {
+    List<QuestRequirement> findByQuestId(Integer questId);
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestRewardItemRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestRewardItemRepository.java
@@ -1,0 +1,12 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestRewardItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestRewardItemRepository extends JpaRepository<QuestRewardItem, Integer> {
+    List<QuestRewardItem> findByQuestId(Integer questId);
+}

--- a/src/main/java/com/maple/api/quest/repository/QuestRewardRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/QuestRewardRepository.java
@@ -1,0 +1,12 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.QuestReward;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QuestRewardRepository extends JpaRepository<QuestReward, Integer> {
+    Optional<QuestReward> findByQuestId(Integer questId);
+}


### PR DESCRIPTION
## 구현 내용 사항 `GET /api/v1/quests/1000`
- 퀘스트 상세 조회 API
  ```json
  {
    "questId": 1000,
    "titlePrefix": "[ 세라의 거울 ]",
    "nameKr": "세라에게 거울 빌려오기",
    "nameEn": "Borrowing Sera's Mirror",
    "iconUrl": "https://maplestory.io/api/gms/62/quest/1000/icon?resize=2",
    "questType": "1회성",
    "minLevel": 0,
    "maxLevel": null,
    "requiredMesoStart": 0,
    "startNpcId": 2101,
    "endNpcId": 2100,
    "reward": {
        "exp": 0,
        "meso": 0,
        "popularity": 0
    },
    "rewardItems": [],
    "requirements": [],
    "allowedJobs": [
        {
            "jobId": 1,
            "jobName": "초보자"
        }
    ]
  }

- 연계 퀘스트 조회 API `GET /api/v1/quests/1011/chain`
  ```json
  {
    "previousQuests": [
        {
            "questId": 1010,
            "name": "레인의 메이플 퀴즈2",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1010/icon?resize=2"
        },
        {
            "questId": 1009,
            "name": "레인의 메이플 퀴즈1",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1009/icon?resize=2"
        }
    ],
    "nextQuests": [
        {
            "questId": 1012,
            "name": "레인의 메이플 퀴즈4",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1012/icon?resize=2"
        },
        {
            "questId": 1013,
            "name": "레인의 메이플 퀴즈5",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1013/icon?resize=2"
        },
        {
            "questId": 1014,
            "name": "레인의 메이플 퀴즈6",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1014/icon?resize=2"
        },
        {
            "questId": 1015,
            "name": "레인의 메이플 퀴즈7",
            "minLevel": 0,
            "maxLevel": null,
            "iconUrl": "https://maplestory.io/api/gms/62/quest/1015/icon?resize=2"
        }
    ]
  }
- 데이터 구조 변경(quest_allowed_jobs)
  - 기존에 job 테이블이 없었기 때문에 job_name으로 설정했던 칼럼을 job_id로 구조를 변경했습니다.
  - 또한 메이플랜드에 맞지 않는 직업 데이터(시그너스, 레지스탕스 등)를 테이블에서 제거했습니다. (현재는 제 로컬에만 설정되어있고, 머지하는 시점에 데이터를 변경할 예정입니다.)
- 추가로 Quest와 관련된 엔티티가 왠지 모르겠지만 강결합으로 롤백되어있어서 다시 약결합으로 수정했습니다. (아마 제가 깃 브랜치를  잘못 따서 그랬던 것 같네요 ㅠ)

## 리뷰 포인트
- job_id를 maplestory.io의 ID로 바꾸는 것을 어떻게 생각하시는 지 궁금합니다. 현재 아이템, 몬스터 등 다른 데이터는 maplestory.io 기반 ID를 활용하고 있는데, 직업 ID는 auto increment로 설정되어 있습니다. 당장은 job_id를 변경해도 의미없지만, 추후에 maplestory.io로부터 데이터를 추가적으로 가져와서 사용하게 된다면 바꾸는 것이 좋아보이기도 합니다. (ref: https://maplestory.io/api/gms/62/job)
  (-> 즉, 1, 2, 3, 4... 로 되어있는 직업 ID를 100, 110, 111 이런 maplestory.io의 직업으로 바꾸기)
- 연계 퀘스트의 경우, prev는 퀘스트 그룹의 sequenceOrder 기준 내림차순, next는 sequenceOrder 기준 오름차순으로 구현했습니다. 
- 또한 추후에 연계 퀘스트가 트리 구조로 변경되었을 경우, API 포맷의 변경을 최소화하는 데에도 초점을 맞췄습니다. 이 부분도 괜찮은지 리뷰 부탁드립니다!