### PR TITLE
멤버 프로필 업데이트 API 추가

### DIFF
--- a/src/main/java/com/maple/api/auth/application/MemberService.java
+++ b/src/main/java/com/maple/api/auth/application/MemberService.java
@@ -5,6 +5,10 @@ import com.maple.api.auth.application.dto.MemberDto;
 import com.maple.api.auth.application.dto.UpdateCommand;
 import com.maple.api.auth.domain.Member;
 import com.maple.api.auth.repository.MemberRepository;
+import com.maple.api.common.presentation.exception.ApiException;
+import com.maple.api.job.domain.Job;
+import com.maple.api.job.exception.JobException;
+import com.maple.api.job.repository.JobRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MemberService {
   private final MemberRepository memberRepository;
+  private final JobRepository jobRepository;
 
   @Transactional
   public Optional<MemberDto> findMember(String memberId) {
@@ -82,6 +87,22 @@ public class MemberService {
           updateAlertAgreement.getPatchNoteAgreement(),
           updateAlertAgreement.getEventAgreement()
         );
+        return m;
+      })
+      .map(MemberDto::toDto);
+  }
+
+  @Transactional
+  public Optional<MemberDto> updateProfile(String memberId, Integer level, Integer jobId) {
+    Optional<Job> jobOpt = jobRepository.findById(jobId);
+    if (jobOpt.isEmpty()) {
+      throw ApiException.of(JobException.JOB_NOT_FOUND);
+    }
+
+    return memberRepository.findById(memberId)
+      .map(m -> {
+        m.setLevel(level);
+        m.setJobId(jobId);
         return m;
       })
       .map(MemberDto::toDto);

--- a/src/main/java/com/maple/api/auth/application/MemberService.java
+++ b/src/main/java/com/maple/api/auth/application/MemberService.java
@@ -83,9 +83,9 @@ public class MemberService {
     return memberRepository.findById(memberId)
       .map(m -> {
         m.setAlertAgreements(
-          updateAlertAgreement.getNoticeAgreement(),
-          updateAlertAgreement.getPatchNoteAgreement(),
-          updateAlertAgreement.getEventAgreement()
+          updateAlertAgreement.noticeAgreement(),
+          updateAlertAgreement.patchNoteAgreement(),
+          updateAlertAgreement.eventAgreement()
         );
         return m;
       })

--- a/src/main/java/com/maple/api/auth/application/dto/MemberDto.java
+++ b/src/main/java/com/maple/api/auth/application/dto/MemberDto.java
@@ -11,7 +11,10 @@ public record MemberDto(
   Boolean marketingAgreement,
   Boolean noticeAgreement,
   Boolean patchNoteAgreement,
-  Boolean eventAgreement
+  Boolean eventAgreement,
+  //
+  Integer jobId,
+  Integer level
 ) {
   public static MemberDto toDto(Member member) {
     return new MemberDto(
@@ -22,7 +25,10 @@ public record MemberDto(
       member.getMarketingAgreement(),
       member.getNoticeAgreement(),
       member.getPatchNoteAgreement(),
-      member.getEventAgreement()
+      member.getEventAgreement(),
+      //
+      member.getJobId(),
+      member.getLevel()
     );
   }
 }

--- a/src/main/java/com/maple/api/auth/application/dto/UpdateCommand.java
+++ b/src/main/java/com/maple/api/auth/application/dto/UpdateCommand.java
@@ -9,39 +9,38 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class UpdateCommand {
-  @Data
-  @AllArgsConstructor
-  public static class NickName {
+  public record NickName(
     @Size(min = 2, max = 15, message = "닉네임은 2자 이상 15자 이하로 입력해야 합니다.")
-    String nickname;
+    String nickname
+  ) {
   }
 
-  @Data
-  @AllArgsConstructor
-  public static class MarketingAgreement {
-    Boolean marketingAgreement;
+  public record MarketingAgreement(
+    Boolean marketingAgreement
+  ) {
   }
 
-  @Data
-  @AllArgsConstructor
-  public static class Agreements {
-    Boolean noticeAgreement;
-    Boolean patchNoteAgreement;
-    Boolean eventAgreement;
+  public record Agreements(
+    Boolean noticeAgreement,
+    Boolean patchNoteAgreement,
+    Boolean eventAgreement
+  ) {
   }
 
-  @Data
-  @AllArgsConstructor
-  public static class FcmToken {
-    String fcmToken;
+
+  public record FcmToken(
+    String fcmToken
+  ) {
   }
 
-  @Data
-  @AllArgsConstructor
-  public static class Profile {
+  //  @Data
+//  @AllArgsConstructor
+//  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public record Profile(
     @Min(value = 1, message = "레벨은 1 이상의 값을 입력해야 합니다.")
     @Max(value = 200, message = "레벨은 200 이하의 값을 입력해야 합니다.")
-    Integer level;
-    Integer jobId;
+    Integer level,
+    Integer jobId
+  ) {
   }
 }

--- a/src/main/java/com/maple/api/auth/application/dto/UpdateCommand.java
+++ b/src/main/java/com/maple/api/auth/application/dto/UpdateCommand.java
@@ -1,5 +1,7 @@
 package com.maple.api.auth.application.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -32,5 +34,14 @@ public class UpdateCommand {
   @AllArgsConstructor
   public static class FcmToken {
     String fcmToken;
+  }
+
+  @Data
+  @AllArgsConstructor
+  public static class Profile {
+    @Min(value = 1, message = "레벨은 1 이상의 값을 입력해야 합니다.")
+    @Max(value = 200, message = "레벨은 200 이하의 값을 입력해야 합니다.")
+    Integer level;
+    Integer jobId;
   }
 }

--- a/src/main/java/com/maple/api/auth/domain/Member.java
+++ b/src/main/java/com/maple/api/auth/domain/Member.java
@@ -51,6 +51,12 @@ public class Member {
   @Builder.Default
   private Boolean eventAgreement = false;
 
+  @Setter
+  private Integer level;
+
+  @Setter
+  private Integer jobId;
+
   // private String role;
   public String getRole() {
     return "ROLE_MEMBER";

--- a/src/main/java/com/maple/api/auth/presentation/restapi/AuthController.java
+++ b/src/main/java/com/maple/api/auth/presentation/restapi/AuthController.java
@@ -161,7 +161,7 @@ public class AuthController {
     @AuthenticationPrincipal PrincipalDetails principalDetails,
     @Valid @RequestBody UpdateCommand.NickName request
   ) {
-    memberService.updateNickname(principalDetails.getProviderId(), request.getNickname());
+    memberService.updateNickname(principalDetails.getProviderId(), request.nickname());
     return ResponseEntity.ok(ResponseTemplate.success(null));
   }
 
@@ -171,7 +171,7 @@ public class AuthController {
     @RequestBody UpdateCommand.FcmToken request
   ) {
 
-    memberService.updateFcmToken(principalDetails.getProviderId(), request.getFcmToken());
+    memberService.updateFcmToken(principalDetails.getProviderId(), request.fcmToken());
     return ResponseEntity.ok(ResponseTemplate.success(null));
   }
 
@@ -180,7 +180,7 @@ public class AuthController {
     @AuthenticationPrincipal PrincipalDetails principalDetails,
     @RequestBody UpdateCommand.MarketingAgreement request
   ) {
-    memberService.updateMarketingAgreement(principalDetails.getProviderId(), request.getMarketingAgreement());
+    memberService.updateMarketingAgreement(principalDetails.getProviderId(), request.marketingAgreement());
     return ResponseEntity.ok(ResponseTemplate.success(null));
   }
 
@@ -205,7 +205,7 @@ public class AuthController {
     @AuthenticationPrincipal PrincipalDetails principalDetails,
     @Valid @RequestBody UpdateCommand.Profile request
   ) {
-    memberService.updateProfile(principalDetails.getProviderId(), request.getLevel(), request.getJobId());
+    memberService.updateProfile(principalDetails.getProviderId(), request.level(), request.jobId());
     return ResponseEntity.ok(ResponseTemplate.success(null));
   }
 

--- a/src/main/java/com/maple/api/auth/presentation/restapi/AuthController.java
+++ b/src/main/java/com/maple/api/auth/presentation/restapi/AuthController.java
@@ -194,6 +194,22 @@ public class AuthController {
   }
 
   @Operation(
+    summary = "회원 프로필 업데이트",
+    description = "회원의 레벨과 직업을 업데이트합니다.\n\n" +
+                  "**Request Body:**\n" +
+                  "- `level`: 1~200 범위의 레벨\n" +
+                  "- `jobId`: 직업 ID\n\n"
+  )
+  @PutMapping("/member/profile")
+  public ResponseEntity<ResponseTemplate<Void>> updateProfile(
+    @AuthenticationPrincipal PrincipalDetails principalDetails,
+    @Valid @RequestBody UpdateCommand.Profile request
+  ) {
+    memberService.updateProfile(principalDetails.getProviderId(), request.getLevel(), request.getJobId());
+    return ResponseEntity.ok(ResponseTemplate.success(null));
+  }
+
+  @Operation(
     summary = "탈퇴하기"
   )
   @DeleteMapping("/member")

--- a/src/test/java/com/maple/api/auth/presentation/AuthControllerE2ETest.java
+++ b/src/test/java/com/maple/api/auth/presentation/AuthControllerE2ETest.java
@@ -3,10 +3,13 @@ package com.maple.api.auth.presentation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.maple.api.auth.application.KakaoUserInfoClient;
+import com.maple.api.auth.application.MemberService;
 import com.maple.api.auth.application.dto.CreateMemberRequestDto;
 import com.maple.api.auth.application.dto.KakaoUserInfo;
 import com.maple.api.auth.application.dto.LoginResponseDto;
+import com.maple.api.auth.application.dto.UpdateCommand;
 import com.maple.api.auth.domain.Member;
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.auth.domain.Provider;
 import com.maple.api.auth.repository.MemberRepository;
 import com.maple.api.common.presentation.restapi.ResponseTemplate;
@@ -27,10 +30,9 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,6 +50,8 @@ public class AuthControllerE2ETest {
   @MockitoBean
   private MemberRepository memberRepository;
 
+  @MockitoBean
+  private MemberService memberService; // MemberService는 실제 빈으로 동작
   // MemberService와 AuthService는 실제 빈으로 동작
 
   @Nested
@@ -135,7 +139,6 @@ public class AuthControllerE2ETest {
       System.out.println(result.getResponse().getContentAsString());
     }
 
-
     @Test
     @DisplayName("성공: 가입된 사용자일 때 JWT 토큰 반환")
     void loginSuccess() throws Exception {
@@ -215,6 +218,34 @@ public class AuthControllerE2ETest {
 
       // verify: 회원 정보 삭제 확인
       verify(memberRepository).deleteById(kakaoUserInfo.getId().toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /api/v1/auth/member/profile")
+  class UpdateMemberProfileTest {
+    @DisplayName("성공: 회원 프로필 업데이트")
+    @Test
+    void updateProfileSuccess() throws Exception {
+      // given
+      String providerId = "kakao:12345678";
+      int level = 120;
+      int jobId = 5;
+      UpdateCommand.Profile requestDto = new UpdateCommand.Profile(level, jobId);
+
+      // then
+      mockMvc.perform(put("/api/v1/auth/member/profile")
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .content(new ObjectMapper().writeValueAsString(requestDto))
+          .with(user(new PrincipalDetails(providerId)))
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data").doesNotExist());
+
+      // verify
+      verify(memberService).updateProfile(providerId, level, jobId);
     }
   }
 

--- a/src/test/java/com/maple/api/auth/presentation/AuthControllerE2ETest.java
+++ b/src/test/java/com/maple/api/auth/presentation/AuthControllerE2ETest.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.maple.api.auth.application.KakaoUserInfoClient;
 import com.maple.api.auth.application.MemberService;
-import com.maple.api.auth.application.dto.CreateMemberRequestDto;
-import com.maple.api.auth.application.dto.KakaoUserInfo;
-import com.maple.api.auth.application.dto.LoginResponseDto;
-import com.maple.api.auth.application.dto.UpdateCommand;
+import com.maple.api.auth.application.dto.*;
 import com.maple.api.auth.domain.Member;
 import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.auth.domain.Provider;
@@ -23,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -49,10 +47,10 @@ public class AuthControllerE2ETest {
 
   @MockitoBean
   private MemberRepository memberRepository;
-
-  @MockitoBean
-  private MemberService memberService; // MemberService는 실제 빈으로 동작
   // MemberService와 AuthService는 실제 빈으로 동작
+
+  @MockitoSpyBean
+  private MemberService memberService;
 
   @Nested
   @DisplayName("POST /api/v1/auth/login/kakao")
@@ -232,6 +230,8 @@ public class AuthControllerE2ETest {
       int level = 120;
       int jobId = 5;
       UpdateCommand.Profile requestDto = new UpdateCommand.Profile(level, jobId);
+      doReturn(Optional.of(mock(MemberDto.class)))
+        .when(memberService).updateProfile(providerId, level, jobId);
 
       // then
       mockMvc.perform(put("/api/v1/auth/member/profile")
@@ -241,8 +241,7 @@ public class AuthControllerE2ETest {
           .with(user(new PrincipalDetails(providerId)))
         )
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.data").doesNotExist());
+        .andExpect(jsonPath("$.success").value(true));
 
       // verify
       verify(memberService).updateProfile(providerId, level, jobId);


### PR DESCRIPTION
## 구현 내용 사항
- 멤버 프로필 수정 API `PUT /api/v1/auth/member/profile`
- Member Entity에 jobId, level 필드 추가

## 리뷰 포인트
- 진훈님 요청으로 추가한 API입니다! 구현이 간단해보여서 재혁님께 전달드리지 않고 제가 구현했습니다.
- 다만 궁금한 점이 UpdateCommand DTO 구조에서 NoArgsConstructor가 없으니 API 요청에 실패하더라구요.. 제 환경에서는 다른 UpdateCommand API도 마찬가지로 실패하는데, 혹시 환경에 차이가 있을까요? (일단 NoArgsConstructor를 추가하지 않고 컨벤션에 맞춰뒀습니다)