### PR TITLE
북마크 조회 API

### DIFF
--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -1,0 +1,21 @@
+package com.maple.api.bookmark.application;
+
+import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.maple.api.bookmark.repository.BookmarkQueryDslRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkQueryService {
+
+    private final BookmarkQueryDslRepository bookmarkQueryDslRepository;
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getBookmarks(String memberId, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchBookmarks(memberId, pageable);
+    }
+}

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -40,4 +40,9 @@ public class BookmarkQueryService {
     public Page<BookmarkSummaryDto> getNpcBookmarks(String memberId, Pageable pageable) {
         return bookmarkQueryDslRepository.searchNpcBookmarks(memberId, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getQuestBookmarks(String memberId, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchQuestBookmarks(memberId, pageable);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -45,4 +45,9 @@ public class BookmarkQueryService {
     public Page<BookmarkSummaryDto> getQuestBookmarks(String memberId, Pageable pageable) {
         return bookmarkQueryDslRepository.searchQuestBookmarks(memberId, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getCollectionBookmarks(String memberId, Integer collectionId, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchCollectionBookmarks(memberId, collectionId, pageable);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -1,6 +1,7 @@
 package com.maple.api.bookmark.application;
 
 import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
 import com.maple.api.bookmark.repository.BookmarkQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,5 +18,10 @@ public class BookmarkQueryService {
     @Transactional(readOnly = true)
     public Page<BookmarkSummaryDto> getBookmarks(String memberId, Pageable pageable) {
         return bookmarkQueryDslRepository.searchBookmarks(memberId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchItemBookmarks(memberId, request, pageable);
     }
 }

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -35,4 +35,9 @@ public class BookmarkQueryService {
     public Page<BookmarkSummaryDto> getMapBookmarks(String memberId, Pageable pageable) {
         return bookmarkQueryDslRepository.searchMapBookmarks(memberId, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getNpcBookmarks(String memberId, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchNpcBookmarks(memberId, pageable);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -2,6 +2,7 @@ package com.maple.api.bookmark.application;
 
 import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
 import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
+import com.maple.api.bookmark.application.dto.MonsterBookmarkSearchRequestDto;
 import com.maple.api.bookmark.repository.BookmarkQueryDslRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,5 +24,10 @@ public class BookmarkQueryService {
     @Transactional(readOnly = true)
     public Page<BookmarkSummaryDto> getItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable) {
         return bookmarkQueryDslRepository.searchItemBookmarks(memberId, request, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchMonsterBookmarks(memberId, request, pageable);
     }
 }

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkQueryService.java
@@ -30,4 +30,9 @@ public class BookmarkQueryService {
     public Page<BookmarkSummaryDto> getMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable) {
         return bookmarkQueryDslRepository.searchMonsterBookmarks(memberId, request, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Page<BookmarkSummaryDto> getMapBookmarks(String memberId, Pageable pageable) {
+        return bookmarkQueryDslRepository.searchMapBookmarks(memberId, pageable);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/CollectionService.java
+++ b/src/main/java/com/maple/api/bookmark/application/CollectionService.java
@@ -110,4 +110,13 @@ public class CollectionService {
 
         return BookmarkAddToCollectionsResponseDto.of(request.collectionIds().size());
     }
+
+    public void validateCollectionOwnership(String memberId, Integer collectionId) {
+        Collection collection = collectionRepository.findById(collectionId)
+                .orElseThrow(() -> new ApiException(BookmarkException.COLLECTION_NOT_FOUND));
+        
+        if (!collection.getMemberId().equals(memberId)) {
+            throw new ApiException(BookmarkException.ACCESS_DENIED);
+        }
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/dto/BookmarkSummaryDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/BookmarkSummaryDto.java
@@ -1,0 +1,22 @@
+package com.maple.api.bookmark.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "북마크 요약 정보")
+public record BookmarkSummaryDto(
+        @Schema(description = "원본 ID (각 타입별 고유 ID)", example = "1002001")
+        Integer originalId,
+        
+        @Schema(description = "이름", example = "메탈 기어")
+        String name,
+        
+        @Schema(description = "이미지 URL", example = "https://maplestory.io/api/gms/62/item/1002001/icon?resize=2")
+        String imageUrl,
+        
+        @Schema(description = "타입 (ITEM, MONSTER, QUEST, NPC, MAP)", example = "ITEM")
+        String type,
+        
+        @Schema(description = "레벨", example = "0")
+        Integer level
+) {
+}

--- a/src/main/java/com/maple/api/bookmark/application/dto/BookmarkSummaryDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/BookmarkSummaryDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "북마크 요약 정보")
 public record BookmarkSummaryDto(
+        Integer bookmarkId,
+
         @Schema(description = "원본 ID (각 타입별 고유 ID)", example = "1002001")
         Integer originalId,
         

--- a/src/main/java/com/maple/api/bookmark/application/dto/ItemBookmarkSearchRequestDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/ItemBookmarkSearchRequestDto.java
@@ -1,0 +1,43 @@
+package com.maple.api.bookmark.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.util.List;
+
+@Schema(description = "아이템 북마크 검색 요청 DTO")
+public record ItemBookmarkSearchRequestDto(
+        @Schema(
+            description = "직업 ID 목록 (특정 직업이 착용 가능한 아이템만 검색)",
+            example = "[1, 2, 5]",
+            nullable = true
+        )
+        List<Integer> jobIds,
+        
+        @Schema(
+            description = "최소 요구 레벨 (1-200)",
+            example = "10",
+            minimum = "1",
+            nullable = true
+        )
+        @Min(value = 1, message = "최소 레벨은 1 이상이어야 합니다")
+        Integer minLevel,
+        
+        @Schema(
+            description = "최대 요구 레벨 (1-200)",
+            example = "100",
+            maximum = "200",
+            nullable = true
+        )
+        @Max(value = 200, message = "최대 레벨은 200 이하여야 합니다")
+        Integer maxLevel,
+        
+        @Schema(
+            description = "카테고리 ID 목록 (특정 카테고리의 아이템만 검색)",
+            example = "[24, 25]",
+            nullable = true
+        )
+        List<Integer> categoryIds
+) {
+}

--- a/src/main/java/com/maple/api/bookmark/application/dto/MonsterBookmarkSearchRequestDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/MonsterBookmarkSearchRequestDto.java
@@ -1,0 +1,27 @@
+package com.maple.api.bookmark.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "몬스터 북마크 검색 요청 DTO")
+public record MonsterBookmarkSearchRequestDto(
+        @Schema(
+            description = "최소 레벨 (1-200)",
+            example = "10",
+            minimum = "1",
+            nullable = true
+        )
+        @Min(value = 1, message = "최소 레벨은 1 이상이어야 합니다")
+        Integer minLevel,
+        
+        @Schema(
+            description = "최대 레벨 (1-200)",
+            example = "100",
+            maximum = "200",
+            nullable = true
+        )
+        @Max(value = 200, message = "최대 레벨은 200 이하여야 합니다")
+        Integer maxLevel
+) {
+}

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -140,4 +140,34 @@ public class BookmarkController {
 
         return ResponseEntity.ok(itemBookmarks);
     }
+
+    @GetMapping("/monsters")
+    @Operation(
+            summary = "몬스터 북마크 조회",
+            description = "사용자가 북마크한 몬스터들을 조회합니다. 다양한 필터링과 정렬 옵션을 제공합니다.\n\n" +
+                    "**필터링 옵션:**\n" +
+                    "- `minLevel`, `maxLevel`: 몬스터 레벨 범위\n\n" +
+                    "**정렬 옵션:**\n" +
+                    "- `createdAt`: 북마크 생성순 (최신순/오래된순)\n" +
+                    "- `name`: 몬스터명 가나다순\n\n" +
+                    "**정렬 사용 예시:**\n" +
+                    "- `sort=createdAt,desc`: 최신 북마크순\n" +
+                    "- `sort=name,asc`: 가나다순\n" +
+                    "- 기본값: 최신 북마크순"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "몬스터 북마크 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Page<BookmarkSummaryDto>> getMonsterBookmarks(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @Valid @ParameterObject MonsterBookmarkSearchRequestDto searchRequest,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+
+        Page<BookmarkSummaryDto> monsterBookmarks = bookmarkQueryService.getMonsterBookmarks(
+                principalDetails.getProviderId(), searchRequest, pageable);
+
+        return ResponseEntity.ok(monsterBookmarks);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -4,12 +4,7 @@ import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.bookmark.application.BookmarkQueryService;
 import com.maple.api.bookmark.application.BookmarkService;
 import com.maple.api.bookmark.application.CollectionService;
-import com.maple.api.bookmark.application.dto.BookmarkAddToCollectionsRequestDto;
-import com.maple.api.bookmark.application.dto.BookmarkAddToCollectionsResponseDto;
-import com.maple.api.bookmark.application.dto.BookmarkResponseDto;
-import org.springdoc.core.annotations.ParameterObject;
-import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
-import com.maple.api.bookmark.application.dto.CreateBookmarkRequestDto;
+import com.maple.api.bookmark.application.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,8 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -112,5 +107,37 @@ public class BookmarkController {
                 principalDetails.getProviderId(), bookmarkId, request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/items")
+    @Operation(
+            summary = "아이템 북마크 조회",
+            description = "사용자가 북마크한 아이템들을 조회합니다. 다양한 필터링과 정렬 옵션을 제공합니다.\n\n" +
+                    "**필터링 옵션:**\n" +
+                    "- `jobIds`: 직업 ID 목록 (특정 직업이 착용 가능한 아이템만 검색)\n" +
+                    "- `minLevel`, `maxLevel`: 요구 레벨 범위\n" +
+                    "- `categoryIds`: 카테고리 ID 목록\n\n" +
+                    "**정렬 옵션:**\n" +
+                    "- `createdAt`: 북마크 생성순 (최신순/오래된순)\n" +
+                    "- `name`: 아이템명 가나다순\n\n" +
+                    "**정렬 사용 예시:**\n" +
+                    "- `sort=createdAt,desc`: 최신 북마크순\n" +
+                    "- `sort=name,asc`: 가나다순\n" +
+                    "- 기본값: 최신 북마크순"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "아이템 북마크 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Page<BookmarkSummaryDto>> getItemBookmarks(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @Valid @ParameterObject ItemBookmarkSearchRequestDto searchRequest,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+
+        Page<BookmarkSummaryDto> itemBookmarks = bookmarkQueryService.getItemBookmarks(
+                principalDetails.getProviderId(), searchRequest, pageable);
+
+        return ResponseEntity.ok(itemBookmarks);
     }
 }

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -224,4 +224,31 @@ public class BookmarkController {
 
         return ResponseEntity.ok(npcBookmarks);
     }
+
+    @GetMapping("/quests")
+    @Operation(
+            summary = "퀘스트 북마크 조회",
+            description = "사용자가 북마크한 퀘스트들을 조회합니다. 정렬과 페이징 옵션을 제공합니다.\n\n" +
+                    "**정렬 옵션:**\n" +
+                    "- `createdAt`: 북마크 생성순 (최신순/오래된순)\n" +
+                    "- `name`: 퀘스트명 가나다순\n\n" +
+                    "**정렬 사용 예시:**\n" +
+                    "- `sort=createdAt,desc`: 최신 북마크순\n" +
+                    "- `sort=name,asc`: 가나다순\n" +
+                    "- 기본값: 최신 북마크순"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "퀘스트 북마크 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Page<BookmarkSummaryDto>> getQuestBookmarks(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+
+        Page<BookmarkSummaryDto> questBookmarks = bookmarkQueryService.getQuestBookmarks(
+                principalDetails.getProviderId(), pageable);
+
+        return ResponseEntity.ok(questBookmarks);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -197,4 +197,31 @@ public class BookmarkController {
 
         return ResponseEntity.ok(mapBookmarks);
     }
+
+    @GetMapping("/npcs")
+    @Operation(
+            summary = "NPC 북마크 조회",
+            description = "사용자가 북마크한 NPC들을 조회합니다. 정렬과 페이징 옵션을 제공합니다.\n\n" +
+                    "**정렬 옵션:**\n" +
+                    "- `createdAt`: 북마크 생성순 (최신순/오래된순)\n" +
+                    "- `name`: NPC명 가나다순\n\n" +
+                    "**정렬 사용 예시:**\n" +
+                    "- `sort=createdAt,desc`: 최신 북마크순\n" +
+                    "- `sort=name,asc`: 가나다순\n" +
+                    "- 기본값: 최신 북마크순"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "NPC 북마크 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Page<BookmarkSummaryDto>> getNpcBookmarks(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+
+        Page<BookmarkSummaryDto> npcBookmarks = bookmarkQueryService.getNpcBookmarks(
+                principalDetails.getProviderId(), pageable);
+
+        return ResponseEntity.ok(npcBookmarks);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -170,4 +170,31 @@ public class BookmarkController {
 
         return ResponseEntity.ok(monsterBookmarks);
     }
+
+    @GetMapping("/maps")
+    @Operation(
+            summary = "맵 북마크 조회",
+            description = "사용자가 북마크한 맵들을 조회합니다. 정렬과 페이징 옵션을 제공합니다.\n\n" +
+                    "**정렬 옵션:**\n" +
+                    "- `createdAt`: 북마크 생성순 (최신순/오래된순)\n" +
+                    "- `name`: 맵명 가나다순\n\n" +
+                    "**정렬 사용 예시:**\n" +
+                    "- `sort=createdAt,desc`: 최신 북마크순\n" +
+                    "- `sort=name,asc`: 가나다순\n" +
+                    "- 기본값: 최신 북마크순"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "맵 북마크 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Page<BookmarkSummaryDto>> getMapBookmarks(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+
+        Page<BookmarkSummaryDto> mapBookmarks = bookmarkQueryService.getMapBookmarks(
+                principalDetails.getProviderId(), pageable);
+
+        return ResponseEntity.ok(mapBookmarks);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -13,4 +13,5 @@ public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchMapBookmarks(String memberId, Pageable pageable);
     Page<BookmarkSummaryDto> searchNpcBookmarks(String memberId, Pageable pageable);
     Page<BookmarkSummaryDto> searchQuestBookmarks(String memberId, Pageable pageable);
+    Page<BookmarkSummaryDto> searchCollectionBookmarks(String memberId, Integer collectionId, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.maple.api.bookmark.repository;
+
+import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BookmarkQueryDslRepository {
+    Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable);
+}

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -1,9 +1,11 @@
 package com.maple.api.bookmark.repository;
 
 import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable);
+    Page<BookmarkSummaryDto> searchItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -2,10 +2,12 @@ package com.maple.api.bookmark.repository;
 
 import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
 import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
+import com.maple.api.bookmark.application.dto.MonsterBookmarkSearchRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable);
     Page<BookmarkSummaryDto> searchItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable);
+    Page<BookmarkSummaryDto> searchMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -11,4 +11,5 @@ public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable);
     Page<BookmarkSummaryDto> searchMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable);
     Page<BookmarkSummaryDto> searchMapBookmarks(String memberId, Pageable pageable);
+    Page<BookmarkSummaryDto> searchNpcBookmarks(String memberId, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -12,4 +12,5 @@ public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable);
     Page<BookmarkSummaryDto> searchMapBookmarks(String memberId, Pageable pageable);
     Page<BookmarkSummaryDto> searchNpcBookmarks(String memberId, Pageable pageable);
+    Page<BookmarkSummaryDto> searchQuestBookmarks(String memberId, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepository.java
@@ -10,4 +10,5 @@ public interface BookmarkQueryDslRepository {
     Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable);
     Page<BookmarkSummaryDto> searchItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable);
     Page<BookmarkSummaryDto> searchMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable);
+    Page<BookmarkSummaryDto> searchMapBookmarks(String memberId, Pageable pageable);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.maple.api.bookmark.repository;
 
 import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
 import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
+import com.maple.api.bookmark.application.dto.MonsterBookmarkSearchRequestDto;
 import com.maple.api.bookmark.domain.BookmarkType;
 import com.maple.api.job.domain.Job;
 import com.querydsl.core.BooleanBuilder;
@@ -26,6 +27,7 @@ import static com.maple.api.bookmark.domain.QBookmark.bookmark;
 import static com.maple.api.item.domain.QEquipmentItem.equipmentItem;
 import static com.maple.api.item.domain.QItem.item;
 import static com.maple.api.item.domain.QItemJob.itemJob;
+import static com.maple.api.monster.domain.QMonster.monster;
 import static com.maple.api.search.domain.QVwSearchSummary.vwSearchSummary;
 
 @Repository
@@ -34,7 +36,12 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
 
     private final JPAQueryFactory queryFactory;
 
-
+    /**
+     * 북마크 전체 조회
+     * @param memberId 멤버 ID
+     * @param pageable 페이징, 정렬
+     * @return 북마크 응답 DTO
+     */
     @Override
     public Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable) {
         // 1. ORDER BY 절 생성
@@ -124,6 +131,13 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
                 .where(bookmark.memberId.eq(memberId));
     }
 
+    /**
+     * 북마크 아이템 조회
+     * @param memberId 멤버 ID
+     * @param request 필터링 데이터
+     * @param pageable 페이징, 정렬
+     * @return 북마크 응답 DTO
+     */
     @Override
     public Page<BookmarkSummaryDto> searchItemBookmarks(String memberId, ItemBookmarkSearchRequestDto request, Pageable pageable) {
         BooleanBuilder whereClause = createItemBookmarkWhereClause(memberId, request);
@@ -211,6 +225,107 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
     private List<OrderSpecifier<?>> createItemOrderClause(Pageable pageable) {
         Map<String, Path<?>> sortableProperties = Map.of(
                 "name", item.nameKr,
+                "createdAt", bookmark.createdAt
+        );
+
+        if (pageable.getSort().isUnsorted()) {
+            return List.of(bookmark.createdAt.desc());
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path));
+            }
+        });
+
+        if (orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(bookmark.createdAt.desc());
+        }
+
+        return orderSpecifiers;
+    }
+
+    /**
+     * 북마크 몬스터 조회
+     * @param memberId 멤버 ID
+     * @param request 몬스터 필터링 데이터
+     * @param pageable 페이징 데이터
+     * @return 북마크 응답 DTO
+     */
+    @Override
+    public Page<BookmarkSummaryDto> searchMonsterBookmarks(String memberId, MonsterBookmarkSearchRequestDto request, Pageable pageable) {
+        BooleanBuilder whereClause = createMonsterBookmarkWhereClause(memberId, request);
+        List<OrderSpecifier<?>> orderClause = createMonsterOrderClause(pageable);
+
+        List<Integer> bookmarkIds = fetchMonsterBookmarkIds(whereClause, orderClause, pageable);
+        if (bookmarkIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<BookmarkSummaryDto> content = fetchMonsterContent(bookmarkIds, orderClause);
+        JPAQuery<Long> countQuery = createMonsterBookmarkCountQuery(whereClause);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanBuilder createMonsterBookmarkWhereClause(String memberId, MonsterBookmarkSearchRequestDto request) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(bookmark.memberId.eq(memberId))
+                .and(bookmark.bookmarkType.eq(BookmarkType.MONSTER));
+
+        if (request.minLevel() != null) {
+            builder.and(monster.level.goe(request.minLevel()));
+        }
+        if (request.maxLevel() != null) {
+            builder.and(monster.level.loe(request.maxLevel()));
+        }
+
+        return builder;
+    }
+
+    private List<Integer> fetchMonsterBookmarkIds(BooleanBuilder where, List<OrderSpecifier<?>> order, Pageable pageable) {
+        return queryFactory
+                .select(bookmark.bookmarkId)
+                .from(bookmark)
+                .join(monster).on(bookmark.resourceId.eq(monster.monsterId))
+                .where(where)
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private List<BookmarkSummaryDto> fetchMonsterContent(List<Integer> bookmarkIds, List<OrderSpecifier<?>> order) {
+        return queryFactory
+                .select(Projections.constructor(BookmarkSummaryDto.class,
+                        bookmark.bookmarkId,
+                        monster.monsterId,
+                        monster.nameKr,
+                        monster.imageUrl,
+                        Expressions.constant("MONSTER"),
+                        monster.level))
+                .from(bookmark)
+                .join(monster).on(bookmark.resourceId.eq(monster.monsterId))
+                .where(bookmark.bookmarkId.in(bookmarkIds))
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private JPAQuery<Long> createMonsterBookmarkCountQuery(BooleanBuilder where) {
+        return queryFactory
+                .select(bookmark.count())
+                .from(bookmark)
+                .join(monster).on(bookmark.resourceId.eq(monster.monsterId))
+                .where(where);
+    }
+
+    private List<OrderSpecifier<?>> createMonsterOrderClause(Pageable pageable) {
+        Map<String, Path<?>> sortableProperties = Map.of(
+                "name", monster.nameKr,
                 "createdAt", bookmark.createdAt
         );
 

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.maple.api.bookmark.repository;
+
+import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.maple.api.bookmark.domain.QBookmark.bookmark;
+import static com.maple.api.search.domain.QVwSearchSummary.vwSearchSummary;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final Map<String, Path<?>> sortableProperties = Map.of(
+            "name", vwSearchSummary.name,
+            "createdAt", bookmark.createdAt
+    );
+
+    @Override
+    public Page<BookmarkSummaryDto> searchBookmarks(String memberId, Pageable pageable) {
+        // 1. ORDER BY 절 생성
+        List<OrderSpecifier<?>> orderClause = createOrderClause(pageable);
+
+        // 2. 최적화된 ID 목록 조회
+        List<Integer> bookmarkIds = fetchBookmarkIds(memberId, orderClause, pageable);
+        if (bookmarkIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 3. ID 목록으로 실제 컨텐츠 조회
+        List<BookmarkSummaryDto> content = fetchContent(bookmarkIds, orderClause);
+
+        // 4. 전체 카운트 쿼리 생성
+        JPAQuery<Long> countQuery = createCountQuery(memberId);
+
+        // 5. Page 객체로 변환하여 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier<?>> createOrderClause(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return List.of(bookmark.createdAt.desc());
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path));
+            }
+        });
+
+        if (orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(bookmark.createdAt.desc());
+        }
+
+        return orderSpecifiers;
+    }
+
+    private List<Integer> fetchBookmarkIds(String memberId, List<OrderSpecifier<?>> order, Pageable pageable) {
+        return queryFactory
+                .select(bookmark.bookmarkId)
+                .from(bookmark)
+                .join(vwSearchSummary).on(
+                        bookmark.resourceId.eq(vwSearchSummary.originalId)
+                                .and(bookmark.bookmarkType.stringValue().eq(vwSearchSummary.type))
+                )
+                .where(bookmark.memberId.eq(memberId))
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private List<BookmarkSummaryDto> fetchContent(List<Integer> bookmarkIds, List<OrderSpecifier<?>> order) {
+        return queryFactory
+                .select(Projections.constructor(BookmarkSummaryDto.class,
+                        vwSearchSummary.originalId,
+                        vwSearchSummary.name,
+                        vwSearchSummary.imageUrl,
+                        vwSearchSummary.type,
+                        vwSearchSummary.level
+                ))
+                .from(bookmark)
+                .join(vwSearchSummary).on(
+                        bookmark.resourceId.eq(vwSearchSummary.originalId)
+                                .and(bookmark.bookmarkType.stringValue().eq(vwSearchSummary.type))
+                )
+                .where(bookmark.bookmarkId.in(bookmarkIds))
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private JPAQuery<Long> createCountQuery(String memberId) {
+        return queryFactory
+                .select(bookmark.count())
+                .from(bookmark)
+                .where(bookmark.memberId.eq(memberId));
+    }
+}

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
@@ -30,6 +30,7 @@ import static com.maple.api.item.domain.QItemJob.itemJob;
 import static com.maple.api.map.domain.QMap.map;
 import static com.maple.api.monster.domain.QMonster.monster;
 import static com.maple.api.npc.domain.QNpc.npc;
+import static com.maple.api.quest.domain.QQuest.quest;
 import static com.maple.api.search.domain.QVwSearchSummary.vwSearchSummary;
 
 @Repository
@@ -514,6 +515,99 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
     private List<OrderSpecifier<?>> createNpcOrderClause(Pageable pageable) {
         Map<String, Path<?>> sortableProperties = Map.of(
                 "name", npc.nameKr,
+                "createdAt", bookmark.createdAt
+        );
+
+        if (pageable.getSort().isUnsorted()) {
+            return List.of(bookmark.createdAt.desc());
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path));
+            }
+        });
+
+        if (orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(bookmark.createdAt.desc());
+        }
+
+        return orderSpecifiers;
+    }
+
+    /**
+     * 북마크 퀘스트 조회
+     * @param memberId 멤버 ID
+     * @param pageable 페이징 데이터
+     * @return 북마크 응답 DTO
+     */
+    @Override
+    public Page<BookmarkSummaryDto> searchQuestBookmarks(String memberId, Pageable pageable) {
+        BooleanBuilder whereClause = createQuestBookmarkWhereClause(memberId);
+        List<OrderSpecifier<?>> orderClause = createQuestOrderClause(pageable);
+
+        List<Integer> bookmarkIds = fetchQuestBookmarkIds(whereClause, orderClause, pageable);
+        if (bookmarkIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<BookmarkSummaryDto> content = fetchQuestContent(bookmarkIds, orderClause);
+        JPAQuery<Long> countQuery = createQuestBookmarkCountQuery(whereClause);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanBuilder createQuestBookmarkWhereClause(String memberId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(bookmark.memberId.eq(memberId))
+                .and(bookmark.bookmarkType.eq(BookmarkType.QUEST));
+
+        return builder;
+    }
+
+    private List<Integer> fetchQuestBookmarkIds(BooleanBuilder where, List<OrderSpecifier<?>> order, Pageable pageable) {
+        return queryFactory
+                .select(bookmark.bookmarkId)
+                .from(bookmark)
+                .join(quest).on(bookmark.resourceId.eq(quest.questId))
+                .where(where)
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private List<BookmarkSummaryDto> fetchQuestContent(List<Integer> bookmarkIds, List<OrderSpecifier<?>> order) {
+        return queryFactory
+                .select(Projections.constructor(BookmarkSummaryDto.class,
+                        bookmark.bookmarkId,
+                        quest.questId,
+                        quest.nameKr,
+                        quest.iconUrl,
+                        Expressions.constant("QUEST"),
+                        Expressions.nullExpression(Integer.class)))
+                .from(bookmark)
+                .join(quest).on(bookmark.resourceId.eq(quest.questId))
+                .where(bookmark.bookmarkId.in(bookmarkIds))
+                .orderBy(order.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private JPAQuery<Long> createQuestBookmarkCountQuery(BooleanBuilder where) {
+        return queryFactory
+                .select(bookmark.count())
+                .from(bookmark)
+                .join(quest).on(bookmark.resourceId.eq(quest.questId))
+                .where(where);
+    }
+
+    private List<OrderSpecifier<?>> createQuestOrderClause(Pageable pageable) {
+        Map<String, Path<?>> sortableProperties = Map.of(
+                "name", quest.nameKr,
                 "createdAt", bookmark.createdAt
         );
 

--- a/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
+++ b/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
@@ -15,9 +15,12 @@ public record SearchSummaryDto(
         String imageUrl,
         
         @Schema(description = "타입 (ITEM, MONSTER, QUEST, NPC, MAP)", example = "ITEM")
-        String type
+        String type,
+
+        @Schema(description = "레벨", example = "0")
+        Integer level
 ) {
     public static SearchSummaryDto toDto(VwSearchSummary entity) {
-        return new SearchSummaryDto(entity.getOriginalId(), entity.getName(), entity.getImageUrl(), entity.getType());
+        return new SearchSummaryDto(entity.getOriginalId(), entity.getName(), entity.getImageUrl(), entity.getType(), entity.getLevel());
     }
 }

--- a/src/main/java/com/maple/api/search/domain/VwSearchSummary.java
+++ b/src/main/java/com/maple/api/search/domain/VwSearchSummary.java
@@ -25,4 +25,7 @@ public class VwSearchSummary {
 
     @Column(name = "type")
     private String type;
+
+    @Column(name = "level")
+    private Integer level;
 }


### PR DESCRIPTION
## 구현 내용 사항
- ViewSearchSummary에 누락된 level 필드 추가
- 북마크 전체 조회 API
- 북마크 아이템 조회 API
- 북마크 몬스터 조회 API
- 북마크 맵 조회 API
- 북마크 NPC 조회 API
- 북마크 퀘스트 조회 API
- 북마크 컬렉션 조회 API

## 리뷰 포인트
북마크 조회 API는 기존 도감 조회 API와 유사합니다.

컬렉션 조회도 올리려고 했는데,,, 당장 로직이나 쿼리를 어떻게 짜야할 지 잘 안 떠올라서 다음 PR에 올려보겠습니다 ㅠ