### PR TITLE
북마크 및 컬렉션 기능 완성

### DIFF
--- a/src/main/java/com/maple/api/bookmark/application/BookmarkFlagService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkFlagService.java
@@ -1,0 +1,36 @@
+package com.maple.api.bookmark.application;
+
+import com.maple.api.bookmark.domain.BookmarkType;
+import com.maple.api.bookmark.repository.BookmarkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkFlagService {
+
+    private final BookmarkRepository bookmarkRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(String memberId, BookmarkType type, Integer resourceId) {
+        if (memberId == null) return false;
+        return bookmarkRepository.existsByMemberIdAndBookmarkTypeAndResourceId(memberId, type, resourceId);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Integer> findBookmarkedIds(String memberId, BookmarkType type, Collection<Integer> resourceIds) {
+        if (memberId == null || resourceIds == null || resourceIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        List<Integer> list = bookmarkRepository.findBookmarkedResourceIds(memberId, type, resourceIds.stream().toList());
+        return new HashSet<>(list);
+    }
+}
+

--- a/src/main/java/com/maple/api/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/maple/api/bookmark/application/BookmarkService.java
@@ -26,4 +26,15 @@ public class BookmarkService {
 
         return BookmarkResponseDto.toDto(bookmarkRepository.save(bookmark));
     }
+
+    public void deleteBookmark(String memberId, Integer bookmarkId) {
+        Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
+                .orElseThrow(() -> new ApiException(BookmarkException.BOOKMARK_NOT_FOUND));
+        
+        if (!bookmark.getMemberId().equals(memberId)) {
+            throw new ApiException(BookmarkException.ACCESS_DENIED);
+        }
+
+        bookmarkRepository.delete(bookmark);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/CollectionQueryService.java
+++ b/src/main/java/com/maple/api/bookmark/application/CollectionQueryService.java
@@ -1,0 +1,21 @@
+package com.maple.api.bookmark.application;
+
+import com.maple.api.bookmark.application.dto.CollectionWithBookmarksDto;
+import com.maple.api.bookmark.repository.CollectionQueryDslRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CollectionQueryService {
+
+    private final CollectionQueryDslRepository collectionQueryDslRepository;
+
+    @Transactional(readOnly = true)
+    public Page<CollectionWithBookmarksDto> getCollectionsWithRecentBookmarks(String memberId, Pageable pageable) {
+        return collectionQueryDslRepository.findCollectionsWithRecentBookmarks(memberId, pageable);
+    }
+}

--- a/src/main/java/com/maple/api/bookmark/application/CollectionService.java
+++ b/src/main/java/com/maple/api/bookmark/application/CollectionService.java
@@ -119,4 +119,16 @@ public class CollectionService {
             throw new ApiException(BookmarkException.ACCESS_DENIED);
         }
     }
+
+    public void deleteCollection(String memberId, Integer collectionId) {
+        Collection collection = collectionRepository.findById(collectionId)
+                .orElseThrow(() -> new ApiException(BookmarkException.COLLECTION_NOT_FOUND));
+        
+        if (!collection.getMemberId().equals(memberId)) {
+            throw new ApiException(BookmarkException.ACCESS_DENIED);
+        }
+
+        bookmarkCollectionRepository.deleteByCollectionId(collectionId);
+        collectionRepository.delete(collection);
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/application/CollectionService.java
+++ b/src/main/java/com/maple/api/bookmark/application/CollectionService.java
@@ -6,6 +6,7 @@ import com.maple.api.bookmark.application.dto.CollectionAddBookmarksRequestDto;
 import com.maple.api.bookmark.application.dto.CollectionAddBookmarksResponseDto;
 import com.maple.api.bookmark.application.dto.CollectionResponseDto;
 import com.maple.api.bookmark.application.dto.CreateCollectionRequestDto;
+import com.maple.api.bookmark.application.dto.UpdateCollectionRequestDto;
 import com.maple.api.bookmark.domain.Bookmark;
 import com.maple.api.bookmark.domain.BookmarkCollection;
 import com.maple.api.bookmark.domain.Collection;
@@ -130,5 +131,18 @@ public class CollectionService {
 
         bookmarkCollectionRepository.deleteByCollectionId(collectionId);
         collectionRepository.delete(collection);
+    }
+
+    public CollectionResponseDto updateCollectionName(String memberId, Integer collectionId, UpdateCollectionRequestDto request) {
+        Collection collection = collectionRepository.findById(collectionId)
+                .orElseThrow(() -> new ApiException(BookmarkException.COLLECTION_NOT_FOUND));
+
+        if (!collection.getMemberId().equals(memberId)) {
+            throw new ApiException(BookmarkException.ACCESS_DENIED);
+        }
+
+        collection.rename(request.name());
+
+        return CollectionResponseDto.toDto(collection);
     }
 }

--- a/src/main/java/com/maple/api/bookmark/application/dto/CollectionWithBookmarksDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/CollectionWithBookmarksDto.java
@@ -1,0 +1,37 @@
+package com.maple.api.bookmark.application.dto;
+
+import com.maple.api.bookmark.domain.Collection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Schema(description = "북마크를 포함한 컬렉션 정보")
+public record CollectionWithBookmarksDto(
+        @Schema(description = "컬렉션 ID", example = "1")
+        Integer collectionId,
+
+        @Schema(description = "컬렉션 이름", example = "내가 좋아하는 장비")
+        String name,
+
+        @Schema(description = "생성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "최신 북마크 목록 (최대 4개)")
+        List<BookmarkSummaryDto> recentBookmarks
+) {
+    
+    public static CollectionWithBookmarksDto of(Collection collection, List<BookmarkSummaryDto> bookmarks) {
+        List<BookmarkSummaryDto> limitedBookmarks = bookmarks.stream()
+                .limit(4)
+                .collect(Collectors.toList());
+        
+        return new CollectionWithBookmarksDto(
+                collection.getCollectionId(),
+                collection.getName(),
+                collection.getCreatedAt(),
+                limitedBookmarks
+        );
+    }
+}

--- a/src/main/java/com/maple/api/bookmark/application/dto/UpdateCollectionRequestDto.java
+++ b/src/main/java/com/maple/api/bookmark/application/dto/UpdateCollectionRequestDto.java
@@ -1,0 +1,14 @@
+package com.maple.api.bookmark.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "컬렉션 수정 요청")
+public record UpdateCollectionRequestDto(
+        @NotBlank(message = "컬렉션 이름은 필수입니다.")
+        @Size(min = 1, max = 18, message = "컬렉션 이름은 1자 이상 18자 이하여야 합니다.")
+        @Schema(description = "수정할 컬렉션 이름", example = "업데이트된 컬렉션 이름")
+        String name
+) {}
+

--- a/src/main/java/com/maple/api/bookmark/domain/Collection.java
+++ b/src/main/java/com/maple/api/bookmark/domain/Collection.java
@@ -29,4 +29,8 @@ public class Collection extends BaseEntity {
         this.memberId = memberId;
         this.name = name;
     }
+
+    public void rename(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/BookmarkController.java
@@ -5,6 +5,7 @@ import com.maple.api.bookmark.application.BookmarkQueryService;
 import com.maple.api.bookmark.application.BookmarkService;
 import com.maple.api.bookmark.application.CollectionService;
 import com.maple.api.bookmark.application.dto.*;
+import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -107,6 +108,27 @@ public class BookmarkController {
                 principalDetails.getProviderId(), bookmarkId, request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{bookmarkId}")
+    @Operation(
+            summary = "북마크 삭제",
+            description = "특정 북마크를 삭제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "북마크 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "북마크를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<Void> deleteBookmark(
+            @Parameter(description = "북마크 ID") @PathVariable Integer bookmarkId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        bookmarkService.deleteBookmark(principalDetails.getProviderId(), bookmarkId);
+
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/items")

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/CollectionController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/CollectionController.java
@@ -10,6 +10,7 @@ import com.maple.api.bookmark.application.dto.CollectionAddBookmarksResponseDto;
 import com.maple.api.bookmark.application.dto.CollectionResponseDto;
 import com.maple.api.bookmark.application.dto.CollectionWithBookmarksDto;
 import com.maple.api.bookmark.application.dto.CreateCollectionRequestDto;
+import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -78,6 +79,27 @@ public class CollectionController {
                 principalDetails.getProviderId(), collectionId, request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{collectionId}")
+    @Operation(
+            summary = "컬렉션 삭제",
+            description = "특정 컬렉션과 해당 컬렉션에 포함된 북마크 관계를 삭제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "컬렉션 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "컬렉션을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<ResponseTemplate<Void>> deleteCollection(
+            @Parameter(description = "컬렉션 ID") @PathVariable Integer collectionId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        collectionService.deleteCollection(principalDetails.getProviderId(), collectionId);
+
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{collectionId}/bookmarks")

--- a/src/main/java/com/maple/api/bookmark/presentation/restapi/CollectionController.java
+++ b/src/main/java/com/maple/api/bookmark/presentation/restapi/CollectionController.java
@@ -10,6 +10,7 @@ import com.maple.api.bookmark.application.dto.CollectionAddBookmarksResponseDto;
 import com.maple.api.bookmark.application.dto.CollectionResponseDto;
 import com.maple.api.bookmark.application.dto.CollectionWithBookmarksDto;
 import com.maple.api.bookmark.application.dto.CreateCollectionRequestDto;
+import com.maple.api.bookmark.application.dto.UpdateCollectionRequestDto;
 import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -161,5 +162,29 @@ public class CollectionController {
                 principalDetails.getProviderId(), pageable);
 
         return ResponseEntity.ok(collections);
+    }
+
+    @PutMapping("/{collectionId}")
+    @Operation(
+            summary = "컬렉션 수정",
+            description = "특정 컬렉션의 이름을 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "컬렉션 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "컬렉션을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<CollectionResponseDto> updateCollectionName(
+            @Parameter(description = "컬렉션 ID") @PathVariable Integer collectionId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @Valid @RequestBody UpdateCollectionRequestDto request) {
+
+        CollectionResponseDto response = collectionService.updateCollectionName(
+                principalDetails.getProviderId(), collectionId, request);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkCollectionRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkCollectionRepository.java
@@ -16,4 +16,6 @@ public interface BookmarkCollectionRepository extends JpaRepository<BookmarkColl
     
     @Query("SELECT bc.collectionId FROM BookmarkCollection bc WHERE bc.bookmarkId = :bookmarkId AND bc.collectionId IN :collectionIds")
     List<Integer> findExistingCollectionIds(@Param("bookmarkId") Integer bookmarkId, @Param("collectionIds") List<Integer> collectionIds);
+    
+    void deleteByCollectionId(Integer collectionId);
 }

--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkRepository.java
@@ -3,9 +3,20 @@ package com.maple.api.bookmark.repository;
 import com.maple.api.bookmark.domain.Bookmark;
 import com.maple.api.bookmark.domain.BookmarkType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Integer> {
     boolean existsByMemberIdAndBookmarkTypeAndResourceId(String memberId, BookmarkType bookmarkType, Integer resourceId);
+
+    @Query("SELECT b.resourceId FROM Bookmark b WHERE b.memberId = :memberId AND b.bookmarkType = :bookmarkType AND b.resourceId IN :resourceIds")
+    java.util.List<Integer> findBookmarkedResourceIds(
+            @Param("memberId") String memberId,
+            @Param("bookmarkType") BookmarkType bookmarkType,
+            @Param("resourceIds") List<Integer> resourceIds
+    );
 }

--- a/src/main/java/com/maple/api/bookmark/repository/CollectionQueryDslRepository.java
+++ b/src/main/java/com/maple/api/bookmark/repository/CollectionQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.maple.api.bookmark.repository;
+
+import com.maple.api.bookmark.application.dto.CollectionWithBookmarksDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CollectionQueryDslRepository {
+    Page<CollectionWithBookmarksDto> findCollectionsWithRecentBookmarks(String memberId, Pageable pageable);
+}

--- a/src/main/java/com/maple/api/bookmark/repository/CollectionQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/CollectionQueryDslRepositoryImpl.java
@@ -1,0 +1,160 @@
+package com.maple.api.bookmark.repository;
+
+import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.maple.api.bookmark.application.dto.CollectionWithBookmarksDto;
+import com.maple.api.bookmark.domain.Collection;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.maple.api.bookmark.domain.QBookmark.bookmark;
+import static com.maple.api.bookmark.domain.QBookmarkCollection.bookmarkCollection;
+import static com.maple.api.bookmark.domain.QCollection.collection;
+import static com.maple.api.search.domain.QVwSearchSummary.vwSearchSummary;
+
+@Repository
+@RequiredArgsConstructor
+public class CollectionQueryDslRepositoryImpl implements CollectionQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CollectionWithBookmarksDto> findCollectionsWithRecentBookmarks(String memberId, Pageable pageable) {
+        // 1단계: 페이징된 컬렉션 ID 조회
+        List<OrderSpecifier<?>> orderSpecifiers = createOrderClause(pageable);
+        List<Integer> collectionIds = fetchCollectionIds(memberId, orderSpecifiers, pageable);
+        
+        if (collectionIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 2단계: 컬렉션 상세 정보 조회
+        List<Collection> collections = fetchCollectionDetails(collectionIds, orderSpecifiers);
+
+        // 3단계: 해당 컬렉션들의 북마크 일괄 조회
+        List<BookmarkSummaryDto> allBookmarks = fetchRecentBookmarksByCollections(memberId, collectionIds);
+
+        // 4단계: 메모리에서 컬렉션별로 북마크 그룹핑 및 제한
+        Map<Integer, List<BookmarkSummaryDto>> bookmarksByCollectionId = allBookmarks.stream()
+                .collect(Collectors.groupingBy(
+                        bookmark -> findCollectionIdByBookmarkId(bookmark.bookmarkId(), collectionIds),
+                        Collectors.toList()
+                ));
+
+        // 5단계: 최종 DTO 조합
+        List<CollectionWithBookmarksDto> content = collections.stream()
+                .map(coll -> {
+                    List<BookmarkSummaryDto> recentBookmarks = bookmarksByCollectionId
+                            .getOrDefault(coll.getCollectionId(), new ArrayList<>())
+                            .stream()
+                            .limit(4)
+                            .collect(Collectors.toList());
+                    
+                    return CollectionWithBookmarksDto.of(coll, recentBookmarks);
+                })
+                .collect(Collectors.toList());
+
+        // 6단계: 전체 카운트 쿼리
+        JPAQuery<Long> countQuery = createCountQuery(memberId);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier<?>> createOrderClause(Pageable pageable) {
+        Map<String, Path<?>> sortableProperties = Map.of(
+                "name", collection.name,
+                "createdAt", collection.createdAt
+        );
+
+        if (pageable.getSort().isUnsorted()) {
+            return List.of(collection.createdAt.desc());
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            Path<?> path = sortableProperties.get(order.getProperty());
+            if (path != null) {
+                @SuppressWarnings("unchecked")
+                OrderSpecifier<?> orderSpecifier = new OrderSpecifier(order.isAscending() ? Order.ASC : Order.DESC, path);
+                orderSpecifiers.add(orderSpecifier);
+            }
+        });
+
+        if (orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(collection.createdAt.desc());
+        }
+
+        return orderSpecifiers;
+    }
+
+    private List<Integer> fetchCollectionIds(String memberId, List<OrderSpecifier<?>> orderSpecifiers, Pageable pageable) {
+        return queryFactory
+                .select(collection.collectionId)
+                .from(collection)
+                .where(collection.memberId.eq(memberId))
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private List<Collection> fetchCollectionDetails(List<Integer> collectionIds, List<OrderSpecifier<?>> orderSpecifiers) {
+        return queryFactory
+                .selectFrom(collection)
+                .where(collection.collectionId.in(collectionIds))
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .fetch();
+    }
+
+    private List<BookmarkSummaryDto> fetchRecentBookmarksByCollections(String memberId, List<Integer> collectionIds) {
+        return queryFactory
+                .select(Projections.constructor(BookmarkSummaryDto.class,
+                        bookmark.bookmarkId,
+                        vwSearchSummary.originalId,
+                        vwSearchSummary.name,
+                        vwSearchSummary.imageUrl,
+                        vwSearchSummary.type,
+                        vwSearchSummary.level
+                ))
+                .from(bookmarkCollection)
+                .join(bookmark).on(bookmarkCollection.bookmarkId.eq(bookmark.bookmarkId))
+                .join(vwSearchSummary).on(
+                        bookmark.resourceId.eq(vwSearchSummary.originalId)
+                                .and(bookmark.bookmarkType.stringValue().eq(vwSearchSummary.type))
+                )
+                .where(bookmarkCollection.collectionId.in(collectionIds)
+                        .and(bookmark.memberId.eq(memberId)))
+                .orderBy(bookmarkCollection.collectionId.asc(), bookmark.createdAt.desc())
+                .fetch();
+    }
+
+    private Integer findCollectionIdByBookmarkId(Integer bookmarkId, List<Integer> collectionIds) {
+        return queryFactory
+                .select(bookmarkCollection.collectionId)
+                .from(bookmarkCollection)
+                .where(bookmarkCollection.bookmarkId.eq(bookmarkId)
+                        .and(bookmarkCollection.collectionId.in(collectionIds)))
+                .fetchFirst();
+    }
+
+    private JPAQuery<Long> createCountQuery(String memberId) {
+        return queryFactory
+                .select(collection.count())
+                .from(collection)
+                .where(collection.memberId.eq(memberId));
+    }
+}

--- a/src/main/java/com/maple/api/item/application/dto/ItemDetailDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemDetailDto.java
@@ -45,10 +45,17 @@ public record ItemDetailDto(
         ItemEquipmentStatsDto equipmentStats,
         
         @Schema(description = "스크롤 상세 정보 (스크롤 아이템의 경우)")
-        ItemScrollDetailDto scrollDetail
+        ItemScrollDetailDto scrollDetail,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     
     public static ItemDetailDto toDto(Item item, Category rootCategory, Category leafCategory, List<Job> availableJobs) {
+        return toDto(item, rootCategory, leafCategory, availableJobs, false);
+    }
+
+    public static ItemDetailDto toDto(Item item, Category rootCategory, Category leafCategory, List<Job> availableJobs, boolean isBookmarked) {
         String itemType = getItemType(item);
         
         return ItemDetailDto.builder()
@@ -64,6 +71,7 @@ public record ItemDetailDto(
                 .requiredStats(getRequiredStats(item))
                 .equipmentStats(getEquipmentStats(item))
                 .scrollDetail(getScrollDetail(item))
+                .isBookmarked(isBookmarked)
                 .build();
     }
     

--- a/src/main/java/com/maple/api/item/application/dto/ItemSummaryDto.java
+++ b/src/main/java/com/maple/api/item/application/dto/ItemSummaryDto.java
@@ -15,14 +15,22 @@ public record ItemSummaryDto(
         String imageUrl,
         
         @Schema(description = "아이템 타입 (고정값: 'item')", example = "item")
-        String type
+        String type,
+
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static ItemSummaryDto toDto(Item entity) {
+        return toDto(entity, false);
+    }
+
+    public static ItemSummaryDto toDto(Item entity, boolean isBookmarked) {
         return new ItemSummaryDto(
-                entity.getItemId(), 
-                entity.getNameKr(), 
+                entity.getItemId(),
+                entity.getNameKr(),
                 entity.getItemImageUrl(),
-                "item"
+                "item",
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
+++ b/src/main/java/com/maple/api/item/presentation/restapi/ItemController.java
@@ -1,5 +1,6 @@
 package com.maple.api.item.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.item.application.ItemService;
 import com.maple.api.item.application.dto.ItemDetailDto;
 import com.maple.api.item.application.dto.ItemMonsterDropDto;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,9 +50,10 @@ public class ItemController {
     )
     public ResponseEntity<Page<ItemSummaryDto>> searchItems(
             @Valid @ParameterObject ItemSearchRequestDto searchRequest,
-            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable) {
-        
-        Page<ItemSummaryDto> results = itemService.searchItems(searchRequest, pageable);
+            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        Page<ItemSummaryDto> results = itemService.searchItems(memberId, searchRequest, pageable);
         return ResponseEntity.ok(results);
     }
 
@@ -63,8 +66,10 @@ public class ItemController {
     )
     public ResponseEntity<ItemDetailDto> getItemDetail(
             @Parameter(description = "아이템 ID", example = "1302000", required = true)
-            @PathVariable Integer id) {
-        ItemDetailDto itemDetail = itemService.getItemDetail(id);
+            @PathVariable Integer id,
+            @org.springframework.security.core.annotation.AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        ItemDetailDto itemDetail = itemService.getItemDetail(memberId, id);
         return ResponseEntity.ok(itemDetail);
     }
 

--- a/src/main/java/com/maple/api/map/application/dto/MapDetailDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapDetailDto.java
@@ -27,9 +27,16 @@ public record MapDetailDto(
         String mapUrl,
         
         @Schema(description = "아이콘 URL")
-        String iconUrl
+        String iconUrl,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static MapDetailDto toDto(Map map) {
+        return toDto(map, false);
+    }
+
+    public static MapDetailDto toDto(Map map, boolean isBookmarked) {
         return new MapDetailDto(
                 map.getMapId(),
                 map.getNameKr(),
@@ -38,7 +45,8 @@ public record MapDetailDto(
                 map.getDetailName(),
                 map.getTopRegionName(),
                 map.getMapUrl(),
-                map.getIconUrl()
+                map.getIconUrl(),
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/map/application/dto/MapSummaryDto.java
+++ b/src/main/java/com/maple/api/map/application/dto/MapSummaryDto.java
@@ -15,9 +15,16 @@ public record MapSummaryDto(
         String imageUrl,
         
         @Schema(description = "데이터 타입 (고정값: 'map')", example = "map")
-        String type
+        String type,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static MapSummaryDto toDto(Map entity) {
-        return new MapSummaryDto(entity.getMapId(), entity.getNameKr(), entity.getIconUrl(), "map");
+        return toDto(entity, false);
+    }
+
+    public static MapSummaryDto toDto(Map entity, boolean isBookmarked) {
+        return new MapSummaryDto(entity.getMapId(), entity.getNameKr(), entity.getIconUrl(), "map", isBookmarked);
     }
 }

--- a/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
+++ b/src/main/java/com/maple/api/map/presentation/restapi/MapController.java
@@ -1,19 +1,24 @@
 package com.maple.api.map.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.map.application.MapService;
 import com.maple.api.map.application.dto.*;
-import org.springframework.data.domain.Sort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -40,8 +45,10 @@ public class MapController {
     })
     public ResponseEntity<Page<MapSummaryDto>> searchMaps(
             @ParameterObject MapSearchRequestDto request,
-            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
-        Page<MapSummaryDto> maps = mapService.searchMaps(request, pageable);
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        Page<MapSummaryDto> maps = mapService.searchMaps(memberId, request, pageable);
         return ResponseEntity.ok(maps);
     }
 
@@ -55,8 +62,10 @@ public class MapController {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 맵"),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    public ResponseEntity<MapDetailDto> getMapDetail(@PathVariable Integer mapId) {
-        MapDetailDto mapDetail = mapService.getMapDetail(mapId);
+    public ResponseEntity<MapDetailDto> getMapDetail(@PathVariable Integer mapId,
+                                                     @org.springframework.security.core.annotation.AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        MapDetailDto mapDetail = mapService.getMapDetail(memberId, mapId);
         return ResponseEntity.ok(mapDetail);
     }
 

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterDetailDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterDetailDto.java
@@ -51,7 +51,10 @@ public record MonsterDetailDto(
         Integer mesoDropRate,
         
         @Schema(description = "속성 효과 정보")
-        MonsterTypeEffectivenessDto typeEffectiveness
+        MonsterTypeEffectivenessDto typeEffectiveness,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static MonsterDetailDto toDto(
             Monster monster,
@@ -73,7 +76,34 @@ public record MonsterDetailDto(
                 monster.getEvasionRate(),
                 monster.getMesoDropAmount(),
                 monster.getMesoDropRate(),
-                typeEffectiveness
+                typeEffectiveness,
+                false
+        );
+    }
+
+    public static MonsterDetailDto toDto(
+            Monster monster,
+            MonsterTypeEffectivenessDto typeEffectiveness,
+            boolean isBookmarked
+    ) {
+        return new MonsterDetailDto(
+                monster.getMonsterId(),
+                monster.getNameKr(),
+                monster.getNameEn(),
+                monster.getImageUrl(),
+                monster.getLevel(),
+                monster.getExp(),
+                monster.getHp(),
+                monster.getMp(),
+                monster.getPhysicalDefense(),
+                monster.getMagicDefense(),
+                monster.getRequiredAccuracy(),
+                monster.getBonusAccuracyPerLevelLower(),
+                monster.getEvasionRate(),
+                monster.getMesoDropAmount(),
+                monster.getMesoDropRate(),
+                typeEffectiveness,
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
+++ b/src/main/java/com/maple/api/monster/application/dto/MonsterSummaryDto.java
@@ -15,14 +15,22 @@ public record MonsterSummaryDto(
         String imageUrl,
         
         @Schema(description = "타입 (고정값: monster)", example = "monster")
-        String type
+        String type,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static MonsterSummaryDto toDto(Monster entity) {
+        return toDto(entity, false);
+    }
+
+    public static MonsterSummaryDto toDto(Monster entity, boolean isBookmarked) {
         return new MonsterSummaryDto(
                 entity.getMonsterId(),
                 entity.getNameKr(),
                 entity.getImageUrl(),
-                "monster"
+                "monster",
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
+++ b/src/main/java/com/maple/api/monster/presentation/restapi/MonsterController.java
@@ -1,12 +1,9 @@
 package com.maple.api.monster.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.common.presentation.exception.ExceptionResponse;
 import com.maple.api.monster.application.MonsterService;
-import com.maple.api.monster.application.dto.MonsterDetailDto;
-import com.maple.api.monster.application.dto.MonsterDropItemDto;
-import com.maple.api.monster.application.dto.MonsterSearchRequestDto;
-import com.maple.api.monster.application.dto.MonsterSpawnMapDto;
-import com.maple.api.monster.application.dto.MonsterSummaryDto;
+import com.maple.api.monster.application.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,13 +13,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,8 +53,10 @@ public class MonsterController {
     })
     public ResponseEntity<Page<MonsterSummaryDto>> searchMonsters(
             @Valid @ParameterObject MonsterSearchRequestDto request,
-            @ParameterObject @PageableDefault(size = 20, sort = "monsterId") Pageable pageable) {
-        return ResponseEntity.ok(monsterService.searchMonsters(request, pageable));
+            @ParameterObject @PageableDefault(size = 20, sort = "monsterId") Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        return ResponseEntity.ok(monsterService.searchMonsters(memberId, request, pageable));
     }
 
     @GetMapping("/{monsterId}")
@@ -79,8 +79,10 @@ public class MonsterController {
     })
     public ResponseEntity<MonsterDetailDto> getMonsterDetail(
             @Parameter(description = "몬스터 ID", required = true, example = "100100")
-            @PathVariable Integer monsterId) {
-        return ResponseEntity.ok(monsterService.getMonsterDetail(monsterId));
+            @PathVariable Integer monsterId,
+            @org.springframework.security.core.annotation.AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        return ResponseEntity.ok(monsterService.getMonsterDetail(memberId, monsterId));
     }
 
     @GetMapping("/{monsterId}/maps")

--- a/src/main/java/com/maple/api/npc/application/dto/NpcDetailDto.java
+++ b/src/main/java/com/maple/api/npc/application/dto/NpcDetailDto.java
@@ -15,14 +15,22 @@ public record NpcDetailDto(
         String nameEn,
         
         @Schema(description = "NPC 상세 아이콘 URL", example = "https://maplestory.io/api/gms/62/npc/9000000/icon")
-        String iconUrlDetail
+        String iconUrlDetail,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static NpcDetailDto toDto(Npc npc) {
+        return toDto(npc, false);
+    }
+
+    public static NpcDetailDto toDto(Npc npc, boolean isBookmarked) {
         return new NpcDetailDto(
                 npc.getNpcId(),
                 npc.getNameKr(),
                 npc.getNameEn(),
-                npc.getIconUrlDetail()
+                npc.getIconUrlDetail(),
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/npc/application/dto/NpcSummaryDto.java
+++ b/src/main/java/com/maple/api/npc/application/dto/NpcSummaryDto.java
@@ -15,9 +15,16 @@ public record NpcSummaryDto(
         String imageUrl,
         
         @Schema(description = "데이터 타입", example = "npc")
-        String type
+        String type,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static NpcSummaryDto toDto(Npc entity) {
-        return new NpcSummaryDto(entity.getNpcId(), entity.getNameKr(), entity.getIconUrlDetail(), "npc");
+        return toDto(entity, false);
+    }
+
+    public static NpcSummaryDto toDto(Npc entity, boolean isBookmarked) {
+        return new NpcSummaryDto(entity.getNpcId(), entity.getNameKr(), entity.getIconUrlDetail(), "npc", isBookmarked);
     }
 }

--- a/src/main/java/com/maple/api/npc/presentation/restapi/NpcController.java
+++ b/src/main/java/com/maple/api/npc/presentation/restapi/NpcController.java
@@ -1,12 +1,9 @@
 package com.maple.api.npc.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.common.presentation.exception.ExceptionResponse;
 import com.maple.api.npc.application.NpcService;
-import com.maple.api.npc.application.dto.NpcDetailDto;
-import com.maple.api.npc.application.dto.NpcQuestDto;
-import com.maple.api.npc.application.dto.NpcSearchRequestDto;
-import com.maple.api.npc.application.dto.NpcSpawnMapDto;
-import com.maple.api.npc.application.dto.NpcSummaryDto;
+import com.maple.api.npc.application.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,14 +12,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -51,8 +49,10 @@ public class NpcController {
     })
     public ResponseEntity<Page<NpcSummaryDto>> searchNpcs(
             @ParameterObject NpcSearchRequestDto request,
-            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
-        Page<NpcSummaryDto> npcs = npcService.searchNpcs(request, pageable);
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        Page<NpcSummaryDto> npcs = npcService.searchNpcs(memberId, request, pageable);
         return ResponseEntity.ok(npcs);
     }
 
@@ -71,8 +71,10 @@ public class NpcController {
     })
     public ResponseEntity<NpcDetailDto> getNpcDetail(
             @Parameter(description = "NPC ID", required = true, example = "1010100")
-            @PathVariable Integer npcId) {
-        return ResponseEntity.ok(npcService.getNpcDetail(npcId));
+            @PathVariable Integer npcId,
+            @org.springframework.security.core.annotation.AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        return ResponseEntity.ok(npcService.getNpcDetail(memberId, npcId));
     }
 
     @GetMapping("/{npcId}/maps")

--- a/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestDetailDto.java
@@ -56,11 +56,20 @@ public record QuestDetailDto(
         List<QuestRequirementDto> requirements,
         
         @Schema(description = "허용 직업 목록")
-        List<QuestJobDto> allowedJobs
+        List<QuestJobDto> allowedJobs,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static QuestDetailDto toDto(Quest quest, QuestRewardDto reward, List<QuestRewardItemDto> rewardItems, 
                                       List<QuestRequirementDto> requirements, List<QuestJobDto> allowedJobs,
                                       String startNpcName, String endNpcName) {
+        return toDto(quest, reward, rewardItems, requirements, allowedJobs, startNpcName, endNpcName, false);
+    }
+
+    public static QuestDetailDto toDto(Quest quest, QuestRewardDto reward, List<QuestRewardItemDto> rewardItems,
+                                       List<QuestRequirementDto> requirements, List<QuestJobDto> allowedJobs,
+                                       String startNpcName, String endNpcName, boolean isBookmarked) {
         return new QuestDetailDto(
                 quest.getQuestId(),
                 quest.getTitlePrefix(),
@@ -78,7 +87,8 @@ public record QuestDetailDto(
                 reward,
                 rewardItems,
                 requirements,
-                allowedJobs
+                allowedJobs,
+                isBookmarked
         );
     }
 }

--- a/src/main/java/com/maple/api/quest/application/dto/QuestSummaryDto.java
+++ b/src/main/java/com/maple/api/quest/application/dto/QuestSummaryDto.java
@@ -15,9 +15,16 @@ public record QuestSummaryDto(
         String imageUrl,
         
         @Schema(description = "데이터 타입 (고정값: 'quest')", example = "quest")
-        String type
+        String type,
+        
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static QuestSummaryDto toDto(Quest entity) {
-        return new QuestSummaryDto(entity.getQuestId(), entity.getNameKr(), entity.getIconUrl(), "quest");
+        return toDto(entity, false);
+    }
+
+    public static QuestSummaryDto toDto(Quest entity, boolean isBookmarked) {
+        return new QuestSummaryDto(entity.getQuestId(), entity.getNameKr(), entity.getIconUrl(), "quest", isBookmarked);
     }
 }

--- a/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
+++ b/src/main/java/com/maple/api/quest/presentation/restapi/QuestController.java
@@ -1,5 +1,6 @@
 package com.maple.api.quest.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.quest.application.QuestService;
 import com.maple.api.quest.application.dto.QuestChainResponseDto;
 import com.maple.api.quest.application.dto.QuestDetailDto;
@@ -10,13 +11,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,8 +45,10 @@ public class QuestController {
     })
     public ResponseEntity<Page<QuestSummaryDto>> searchQuests(
             @ParameterObject QuestSearchRequestDto request,
-            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
-        Page<QuestSummaryDto> quests = questService.searchQuests(request, pageable);
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        Page<QuestSummaryDto> quests = questService.searchQuests(memberId, request, pageable);
         return ResponseEntity.ok(quests);
     }
 
@@ -58,8 +62,10 @@ public class QuestController {
         @ApiResponse(responseCode = "404", description = "퀘스트를 찾을 수 없음"),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    public ResponseEntity<QuestDetailDto> getQuestDetail(@PathVariable Integer questId) {
-        QuestDetailDto questDetail = questService.getQuestDetail(questId);
+    public ResponseEntity<QuestDetailDto> getQuestDetail(@PathVariable Integer questId,
+                                                         @org.springframework.security.core.annotation.AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        QuestDetailDto questDetail = questService.getQuestDetail(memberId, questId);
         return ResponseEntity.ok(questDetail);
     }
 

--- a/src/main/java/com/maple/api/search/application/SearchService.java
+++ b/src/main/java/com/maple/api/search/application/SearchService.java
@@ -1,5 +1,7 @@
 package com.maple.api.search.application;
 
+import com.maple.api.bookmark.application.BookmarkFlagService;
+import com.maple.api.bookmark.domain.BookmarkType;
 import com.maple.api.search.application.dto.SearchSummaryDto;
 import com.maple.api.search.domain.VwSearchSummary;
 import com.maple.api.search.repository.VwSearchSummaryQueryDslRepository;
@@ -9,16 +11,53 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
     private final VwSearchSummaryQueryDslRepository vwSearchSummaryQueryDslRepository;
+    private final BookmarkFlagService bookmarkFlagService;
 
     @Transactional(readOnly = true)
-    public Page<SearchSummaryDto> search(String keyword, Pageable pageable) {
+    public Page<SearchSummaryDto> search(String memberId, String keyword, Pageable pageable) {
         Page<VwSearchSummary> resultPage = vwSearchSummaryQueryDslRepository.search(keyword, pageable);
-        return resultPage.map(SearchSummaryDto::toDto);
+
+        List<VwSearchSummary> content = resultPage.getContent();
+        Map<Integer, Boolean> flagMap = buildBookmarkFlagMap(memberId, content);
+
+        return resultPage.map(e -> SearchSummaryDto.toDto(e, flagMap.getOrDefault(e.getOriginalId(), false)));
     }
 
+    private Map<Integer, Boolean> buildBookmarkFlagMap(String memberId, List<VwSearchSummary> content) {
+        if (memberId == null || content.isEmpty()) return Collections.emptyMap();
+
+        Map<String, List<Integer>> idsByType = content.stream()
+                .collect(Collectors.groupingBy(VwSearchSummary::getType,
+                        Collectors.mapping(VwSearchSummary::getOriginalId, Collectors.toList())));
+
+        Map<Integer, Boolean> result = new HashMap<>();
+
+        idsByType.forEach((typeStr, ids) -> {
+            BookmarkType type = switch (typeStr) {
+                case "ITEM" -> BookmarkType.ITEM;
+                case "MONSTER" -> BookmarkType.MONSTER;
+                case "NPC" -> BookmarkType.NPC;
+                case "QUEST" -> BookmarkType.QUEST;
+                case "MAP" -> BookmarkType.MAP;
+                default -> null;
+            };
+
+            if (type != null) {
+                Set<Integer> bookmarked = bookmarkFlagService.findBookmarkedIds(memberId, type, ids);
+                for (Integer id : ids) {
+                    result.put(id, bookmarked.contains(id));
+                }
+            }
+        });
+
+        return result;
+    }
 }

--- a/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
+++ b/src/main/java/com/maple/api/search/application/dto/SearchSummaryDto.java
@@ -18,9 +18,16 @@ public record SearchSummaryDto(
         String type,
 
         @Schema(description = "레벨", example = "0")
-        Integer level
+        Integer level,
+
+        @Schema(description = "로그인 사용자의 북마크 여부", example = "false")
+        boolean isBookmarked
 ) {
     public static SearchSummaryDto toDto(VwSearchSummary entity) {
-        return new SearchSummaryDto(entity.getOriginalId(), entity.getName(), entity.getImageUrl(), entity.getType(), entity.getLevel());
+        return toDto(entity, false);
+    }
+
+    public static SearchSummaryDto toDto(VwSearchSummary entity, boolean isBookmarked) {
+        return new SearchSummaryDto(entity.getOriginalId(), entity.getName(), entity.getImageUrl(), entity.getType(), entity.getLevel(), isBookmarked);
     }
 }

--- a/src/main/java/com/maple/api/search/presentation/restapi/SearchController.java
+++ b/src/main/java/com/maple/api/search/presentation/restapi/SearchController.java
@@ -1,5 +1,6 @@
 package com.maple.api.search.presentation.restapi;
 
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.search.application.SearchService;
 import com.maple.api.search.application.dto.SearchSummaryDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,15 +10,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springdoc.core.annotations.ParameterObject;
 
 @RestController
 @RequestMapping("/api/v1/search")
@@ -50,8 +52,10 @@ public class SearchController {
     public ResponseEntity<Page<SearchSummaryDto>> search(
             @Parameter(description = "검색할 키워드 (최대 100자)", example = "슬라임")
             @RequestParam(required = false) @Size(max = 100) String keyword,
-            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable) {
-        Page<SearchSummaryDto> results = searchService.search(keyword, pageable);
+            @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String memberId = principalDetails != null ? principalDetails.getProviderId() : null;
+        Page<SearchSummaryDto> results = searchService.search(memberId, keyword, pageable);
         return ResponseEntity.ok(results);
     }
 }

--- a/src/main/java/com/maple/api/search/repository/VwSearchSummaryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/search/repository/VwSearchSummaryQueryDslRepositoryImpl.java
@@ -3,6 +3,9 @@ package com.maple.api.search.repository;
 import com.maple.api.search.domain.QVwSearchSummary;
 import com.maple.api.search.domain.VwSearchSummary;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -30,12 +34,14 @@ public class VwSearchSummaryQueryDslRepositoryImpl implements VwSearchSummaryQue
             builder.and(vwSearchSummary.name.contains(keyword));
         }
 
+        List<OrderSpecifier<?>> orderSpecifiers = buildOrderSpecifiers(vwSearchSummary, pageable);
+
         List<VwSearchSummary> content = queryFactory
                 .selectFrom(vwSearchSummary)
                 .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(vwSearchSummary.name.asc())
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
@@ -44,6 +50,31 @@ public class VwSearchSummaryQueryDslRepositoryImpl implements VwSearchSummaryQue
                 .where(builder);
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier<?>> buildOrderSpecifiers(QVwSearchSummary vw, Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String property = order.getProperty();
+            ComparableExpressionBase<?> expression = switch (property) {
+                case "name" -> vw.name;
+                case "level" -> vw.level;
+                case "type" -> vw.type;
+                case "originalId" -> vw.originalId;
+                default -> null;
+            };
+            if (expression != null) {
+                orders.add(new OrderSpecifier<>(direction, expression));
+            }
+        });
+
+        if (orders.isEmpty()) {
+            orders.add(vw.name.asc());
+        }
+
+        return orders;
     }
 
 }


### PR DESCRIPTION
### 요약
북마크와 컬렉션 관리 기능을 완성했습니다.

### 구현 내용 사항

- 각 타입별 검색/상세 조회 API에 현재 유저의 북마크 여부 추가
- 컬렉션 조회 API (페이징, 정렬, 최신 북마크 4개 포함)
- 컬렉션 수정 API (이름 변경)
- 북마크/컬렉션 삭제 API
- 성능 최적화를 위한 네이티브 쿼리 도입

###  예시
- 아이템 검색 API `/api/v1/items/search`
```java
{
  "content": [
    {
      "itemId": 1012000,
      "name": "전사의 검",
      "level": 30,
      "imageUrl": "https://maplestory.io/api/gms/62/item/1012000/icon",
      "isBookmarked": true
    }
  ]
}
```
  
- 컬렉션 목록 조회 API 예시 `/api/v1/collections`
```java
{
  "content": [
    {
      "collectionId": 1,
      "name": "내가 좋아하는 장비",
      "createdAt": "2024-01-01T00:00:00",
      "recentBookmarks": [
        {
          "bookmarkId": 101,
          "originalId": 1012000,
          "name": "전사의 검",
          "imageUrl": "https://maplestory.io/api/gms/62/item/1012000/icon",
          "type": "ITEM",
          "level": 30
        }
      ]
    }
  ]
}
```
- 컬렉션 수정 API 예시 PUT `/api/v1/collections/{collectionId}`
```java
{
  "collectionId": 1,
  "name": "업데이트된 컬렉션 이름",
  "createdAt": "2024-01-01T00:00:00"
}
```
###   리뷰 포인트

이번 작업에서는 북마크와 컬렉션 기능을 완전하게 구현했습니다.

1. 북마크 여부 통합
기존 검색/상세 조회 API들에 isBookmarked 필드를 추가했습니다. BookmarkFlagService를 새로 만들어서 개별 조회와 리스트 조회를 모두 지원하도록 했습니다.

2. 네이티브 쿼리 활용
컬렉션 조회 API에서 각 컬렉션마다 최신 북마크 4개를 가져오는 로직을 윈도우 함수를 사용한 네이티브 쿼리로 구현했습니다.