### PR TITLE
feat: 연계 퀘스트 조회 시, (비선형적 구조 + 1-depth) 형태로 데이터 조회

### DIFF
--- a/src/main/java/com/maple/api/quest/application/QuestService.java
+++ b/src/main/java/com/maple/api/quest/application/QuestService.java
@@ -22,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -38,7 +37,9 @@ public class QuestService {
     private final QuestRewardItemRepository questRewardItemRepository;
     private final QuestRequirementRepository questRequirementRepository;
     private final QuestAllowedJobRepository questAllowedJobRepository;
-    private final QuestChainMemberRepository questChainMemberRepository;
+    private static final List<Integer> CHAIN_STATES = List.of(1, 2);
+
+    private final PrerequisiteQuestRepository prerequisiteQuestRepository;
     private final ItemRepository itemRepository;
     private final MonsterRepository monsterRepository;
     private final JobRepository jobRepository;
@@ -177,47 +178,21 @@ public class QuestService {
     @Transactional(readOnly = true)
     public QuestChainResponseDto getQuestChain(Integer questId) {
         findQuest(questId);
-        
-        QuestChainMember currentChainMember = findQuestChainMember(questId);
-        if (currentChainMember == null) {
-            return QuestChainResponseDto.of(List.of(), List.of());
-        }
-        
-        List<QuestChainMember> allChainMembers = findAllChainMembers(currentChainMember.getChainId());
-        Integer currentSequenceOrder = currentChainMember.getSequenceOrder();
-        
-        List<QuestChainDto> previousQuests = buildPreviousQuests(allChainMembers, currentSequenceOrder);
-        List<QuestChainDto> nextQuests = buildNextQuests(allChainMembers, currentSequenceOrder);
-        
+
+        List<Integer> previousQuestIds = prerequisiteQuestRepository.findByQuestIdAndStateIn(questId, CHAIN_STATES).stream()
+                .map(PrerequisiteQuest::getRequiredToStartQuestId)
+                .sorted()
+                .toList();
+
+        List<Integer> nextQuestIds = prerequisiteQuestRepository.findByRequiredToStartQuestIdAndStateIn(questId, CHAIN_STATES).stream()
+                .map(PrerequisiteQuest::getQuestId)
+                .sorted()
+                .toList();
+
+        List<QuestChainDto> previousQuests = buildQuestChainDtos(previousQuestIds);
+        List<QuestChainDto> nextQuests = buildQuestChainDtos(nextQuestIds);
+
         return QuestChainResponseDto.of(previousQuests, nextQuests);
-    }
-
-    private QuestChainMember findQuestChainMember(Integer questId) {
-        return questChainMemberRepository.findByQuestId(questId).orElse(null);
-    }
-
-    private List<QuestChainMember> findAllChainMembers(Integer chainId) {
-        return questChainMemberRepository.findByChainId(chainId);
-    }
-
-    private List<QuestChainDto> buildPreviousQuests(List<QuestChainMember> allChainMembers, Integer currentSequenceOrder) {
-        List<Integer> previousQuestIds = allChainMembers.stream()
-                .filter(member -> member.getSequenceOrder() < currentSequenceOrder)
-                .sorted((a, b) -> Integer.compare(b.getSequenceOrder(), a.getSequenceOrder()))
-                .map(QuestChainMember::getQuestId)
-                .toList();
-        
-        return buildQuestChainDtos(previousQuestIds);
-    }
-
-    private List<QuestChainDto> buildNextQuests(List<QuestChainMember> allChainMembers, Integer currentSequenceOrder) {
-        List<Integer> nextQuestIds = allChainMembers.stream()
-                .filter(member -> member.getSequenceOrder() > currentSequenceOrder)
-                .sorted(Comparator.comparing(QuestChainMember::getSequenceOrder))
-                .map(QuestChainMember::getQuestId)
-                .toList();
-        
-        return buildQuestChainDtos(nextQuestIds);
     }
 
     private List<QuestChainDto> buildQuestChainDtos(List<Integer> questIds) {

--- a/src/main/java/com/maple/api/quest/domain/PrerequisiteQuest.java
+++ b/src/main/java/com/maple/api/quest/domain/PrerequisiteQuest.java
@@ -1,0 +1,30 @@
+package com.maple.api.quest.domain;
+
+import com.maple.api.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "quest_prerequisite_quests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PrerequisiteQuest extends BaseEntity {
+    @Id
+    private Integer id;
+
+    @Column(name = "quest_id")
+    private Integer questId;
+
+    @Column(name = "required_to_start_quest_id")
+    private Integer requiredToStartQuestId;
+
+    @Column(name = "state")
+    private Integer state;
+}

--- a/src/main/java/com/maple/api/quest/repository/PrerequisiteQuestRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/PrerequisiteQuestRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 @Repository
 public interface PrerequisiteQuestRepository extends JpaRepository<PrerequisiteQuest, Integer> {
-    List<PrerequisiteQuest> findByQuestId(Integer questId);
-    List<PrerequisiteQuest> findByRequiredToStartQuestId(Integer requiredToStartQuestId);
+    List<PrerequisiteQuest> findByQuestIdAndStateIn(Integer questId, List<Integer> states);
+    List<PrerequisiteQuest> findByRequiredToStartQuestIdAndStateIn(Integer requiredToStartQuestId, List<Integer> states);
 }

--- a/src/main/java/com/maple/api/quest/repository/PrerequisiteQuestRepository.java
+++ b/src/main/java/com/maple/api/quest/repository/PrerequisiteQuestRepository.java
@@ -1,0 +1,13 @@
+package com.maple.api.quest.repository;
+
+import com.maple.api.quest.domain.PrerequisiteQuest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PrerequisiteQuestRepository extends JpaRepository<PrerequisiteQuest, Integer> {
+    List<PrerequisiteQuest> findByQuestId(Integer questId);
+    List<PrerequisiteQuest> findByRequiredToStartQuestId(Integer requiredToStartQuestId);
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,24 +3,31 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml" />
     <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>${GRAFANA_CLOUD_URL}/loki/api/v1/push</url>
-            <auth>
-                <username>${GRAFANA_CLOUD_USERNAME}</username>
-                <password>${GRAFANA_CLOUD_PASSWORD}</password>
-            </auth>
-        </http>
+    <springProfile name="prod">
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>${GRAFANA_CLOUD_URL}/loki/api/v1/push</url>
+                <auth>
+                    <username>${GRAFANA_CLOUD_USERNAME}</username>
+                    <password>${GRAFANA_CLOUD_PASSWORD}</password>
+                </auth>
+            </http>
 
-        <labels>
-            service_name    = mapleland-api
-            cloud_provider  = ${CLOUD_PROVIDER}
-            level           = %level
-        </labels>
-    </appender>
+            <labels>
+                service_name    = mapleland-api
+                cloud_provider  = ${CLOUD_PROVIDER}
+                level           = %level
+            </labels>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOKI" />
+        </root>
+    </springProfile>
 
-    <root level="INFO">
-        <appender-ref ref="LOKI" />
-        <appender-ref ref="CONSOLE" />
-    </root>
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## 요약
연계 퀘스트 조회 시, (비선형적 구조 + 1-depth) 형태로 데이터 조회합니다.

## 구현 내용 사항
1. QuestChain.java, QuestChainMemeber.java 엔티티는 그대로 두고, PrerequisiteQuest.java라는 엔티티가 추가되었습니다.
2. 기존의 선형적 구조 -> 비선형적 구조 + 1-depth 형태로 연계 퀘스트 응답이 수정되었습니다.
3. logback-spring.xml에서 로컬 개발 시 그라파나 클라우드 관련 환경 변수 입력이 필요하지 않게 수정했습니다.