### PR TITLE
fix: 메이플랜드 공식 사이트 이전으로 인한 크롤러 수정 및 API 변경

### DIFF
--- a/src/main/java/com/maple/api/alrim/application/command/AlrimCommandService.java
+++ b/src/main/java/com/maple/api/alrim/application/command/AlrimCommandService.java
@@ -1,27 +1,35 @@
 package com.maple.api.alrim.application.command;
 
+import com.maple.api.alrim.domain.Alrim;
 import com.maple.api.alrim.domain.AlrimRead;
+import com.maple.api.alrim.exception.AlrimException;
 import com.maple.api.alrim.repository.AlrimReadRepository;
+import com.maple.api.alrim.repository.AlrimRepository;
+import com.maple.api.common.presentation.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlrimCommandService {
   private final AlrimReadRepository alrimReadRepository;
+  private final AlrimRepository alrimRepository;
 
+  @Transactional
   public void setReadAlrim(
     String memberId,
     String alrimLink
   ) {
-    val alrimRead = new AlrimRead(
-      alrimLink,
-      memberId
-    );
+    Alrim alrim = alrimRepository.findByLink(alrimLink)
+      .orElseThrow(() -> ApiException.of(AlrimException.ALRIM_NOT_FOUND));
 
-    alrimReadRepository.save(alrimRead);
+    if (alrimReadRepository.existsByMemberIdAndAlrimId(memberId, alrim.getId())) {
+      return;
+    }
+
+    alrimReadRepository.save(new AlrimRead(alrim.getId(), alrimLink, memberId));
   }
 }

--- a/src/main/java/com/maple/api/alrim/application/command/AlrimCrawler.java
+++ b/src/main/java/com/maple/api/alrim/application/command/AlrimCrawler.java
@@ -1,87 +1,14 @@
 package com.maple.api.alrim.application.command;
 
 import com.maple.api.alrim.domain.Alrim;
-import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-@Slf4j
-@Component
-public class AlrimCrawler {
-  DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
-  private final String BaseUrlString = "https://public.maple.land";
+public interface AlrimCrawler {
+  List<Alrim> crawlNotices() throws IOException;
 
-  public List<Alrim> crawlNotices() throws IOException {
-    String url = "https://public.maple.land/notice";
-    Document doc = Jsoup.connect(url)
-      .userAgent("Mozilla/5.0")
-      .get();
+  List<Alrim> crawlPatchNotes() throws IOException;
 
-    return doc.select("div.notion-collection-item")
-      .stream().map(el -> {
-        String link = el.selectFirst("a").attr("href");
-
-        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
-        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
-
-//        log.info("제목: {}, 날짜: {}, 링크: {}", title, date, link);
-        return Alrim.createNotice(
-          title,
-          LocalDateTime.parse(date, formatter).plusHours(9),
-          BaseUrlString + link
-        );
-      })
-      .filter(it -> it.getTitle().length() >= 10)
-      .toList();
-  }
-
-  public List<Alrim> crawlPatchNotes() throws IOException {
-    String url = "https://public.maple.land/update";
-    Document doc = Jsoup.connect(url)
-      .userAgent("Mozilla/5.0")
-      .get();
-
-    return doc.select("div.notion-collection-item")
-      .stream().map(el -> {
-        String link = el.selectFirst("a").attr("href");
-
-        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
-        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
-
-//        log.info("제목: {}, 날짜: {}, 링크: {}", title, date, link);
-        return Alrim.createPatchNote(
-          title,
-          LocalDateTime.parse(date, formatter).plusHours(9),
-          BaseUrlString + link
-        );
-      }).filter(it -> it.getTitle().length() >= 10).toList();
-  }
-
-  public List<Alrim> crawlEvents() throws IOException {
-    String url = "https://public.maple.land/events";
-    Document doc = Jsoup.connect(url)
-      .userAgent("Mozilla/5.0")
-      .get();
-
-    return doc.select("div.notion-collection-item")
-      .stream().map(el -> {
-        String link = el.selectFirst("a").attr("href");
-
-        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
-        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
-
-//        log.info("제목: {}, 날짜: {}, 링크: {}", title, date, link);
-        return Alrim.createEvents(
-          title,
-          LocalDateTime.parse(date, formatter).plusHours(9),
-          BaseUrlString + link
-        );
-      }).filter(it -> it.getTitle().length() >= 10).toList();
-  }
+  List<Alrim> crawlEvents() throws IOException;
 }

--- a/src/main/java/com/maple/api/alrim/application/command/AlrimEventBatch.java
+++ b/src/main/java/com/maple/api/alrim/application/command/AlrimEventBatch.java
@@ -9,9 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Component
@@ -19,84 +17,60 @@ import java.util.List;
 @ConditionalOnProperty(name = "batch.alrim-event.enabled", havingValue = "true")
 public class AlrimEventBatch {
   private final AlrimCommandMediator commandBatchMediator;
+  private final MaplelandAlrimBatchService mapleLandAlrimBatchService;
   private final AlrimCrawler crawler;
   private final AlrimFcmManager alrimFcmManager;
 
   // 서버 다중화시 락 필요
   // 매일 09:00~20:00 사이 0분에 실행
-  @Scheduled(cron = "0 0 9-20 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+//  @Scheduled(cron = "0 0 9-20 * * *", zone = "Asia/Seoul")
 //  @Scheduled(initialDelay = 0, fixedRate = 60 * 1000 * 60) // 1시간마다 실행 (테스트용)
   public void runCollectBatch() {
     val fcmCandidates = new ArrayList<Alrim>();
 
     // STEP 01. 공지사항
     try {
-      val notices = crawlNotices();
-      commandBatchMediator.saveAll(notices);
-      fcmCandidates.addAll(notices);
+      val notices = crawler.crawlNotices();
+      val noticesWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.NOTICE, notices);
+      commandBatchMediator.saveAll(noticesWithoutExisting);
+//      fcmCandidates.addAll(noticesWithoutExisting);
 
-      log.info("공지사항 배치 저장 완료 {}", notices.size());
+      log.info("공지사항 배치 저장 완료 {}", noticesWithoutExisting.size());
     } catch (Exception e) {
       log.error("공지사항 배치 저장 실패", e);
     }
 
     // STEP 02. 패치노트
     try {
-      val patchNotes = crawlPatchNotes();
-      commandBatchMediator.saveAll(patchNotes);
-      fcmCandidates.addAll(patchNotes);
+      val patchNotes = crawler.crawlPatchNotes();
+      val patchNotesWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.PATCH_NOTE, patchNotes);
+      commandBatchMediator.saveAll(patchNotesWithoutExisting);
+//      fcmCandidates.addAll(patchNotesWithoutExisting);
 
-      log.info("패치노트 배치 저장 완료 {}", patchNotes.size());
+      log.info("패치노트 배치 저장 완료 {}", patchNotesWithoutExisting.size());
     } catch (Exception e) {
       log.error("패치노트 배치 저장 실패", e);
     }
 
     // STEP 03. 새로운 이벤트 처리
     try {
-      val events = crawlOnAllGoingEvents();
-      val newEvents = newEventsForFCM(events);
-      commandBatchMediator.saveAll(newEvents);
-      fcmCandidates.addAll(newEvents);
+      val events = crawler.crawlEvents();
+      val eventsWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.EVENT, events);
+      commandBatchMediator.saveAll(eventsWithoutExisting);
+//      fcmCandidates.addAll(eventsWithoutExisting.stream().filter(it -> !it.getOutdated()).toList());
 
-      // 지난 이벤트는 Out Dated  처리
-      commandBatchMediator.changeEventOutDatedExclude(events);
+      // 종료 상태 반영 및 누락된 진행중 이벤트 종료 처리
+      mapleLandAlrimBatchService.syncEventOutdatedStatusFromCrawl(events);
 
-      log.info("진행중인 이벤트 배치 저장 완료 {}", newEvents.size());
+      log.info("이벤트 배치 저장 완료 {}", eventsWithoutExisting.size());
     } catch (Exception e) {
-      log.error("진행중인 이벤트 배치 저장 실패", e);
+      log.error("이벤트 배치 저장 실패", e);
     }
 
     // STEP 05. Fcm 전송 (FCM 은 도메인 이벤트보다는 어플리케이션 이벤트 레벨로 처리)
     if (!fcmCandidates.isEmpty()) {
       alrimFcmManager.sendFcmMessage(fcmCandidates.getFirst());
     }
-  }
-
-  private List<Alrim> crawlNotices() throws IOException {
-    var dateTime = commandBatchMediator.getRecentCreatedAt(AlrimType.NOTICE);
-    return crawler.crawlNotices()
-      .stream()
-      .filter(it -> it.getDate().isAfter(dateTime))
-      .toList();
-  }
-
-  private List<Alrim> crawlPatchNotes() throws IOException {
-    var dateTime = commandBatchMediator.getRecentCreatedAt(AlrimType.PATCH_NOTE);
-    return crawler.crawlPatchNotes()
-      .stream()
-      .filter(it -> it.getDate().isAfter(dateTime))
-      .toList();
-  }
-
-  private List<Alrim> crawlOnAllGoingEvents() throws IOException {
-    return crawler.crawlEvents();
-  }
-
-  private List<Alrim> newEventsForFCM(List<Alrim> alrimsList) throws IOException {
-    var dateTime = commandBatchMediator.getRecentCreatedAt(AlrimType.EVENT);
-    return alrimsList
-      .stream()
-      .filter(it -> it.getDate().isAfter(dateTime))
-      .toList();
   }
 }

--- a/src/main/java/com/maple/api/alrim/application/command/AlrimEventBatch.java
+++ b/src/main/java/com/maple/api/alrim/application/command/AlrimEventBatch.java
@@ -23,8 +23,7 @@ public class AlrimEventBatch {
 
   // 서버 다중화시 락 필요
   // 매일 09:00~20:00 사이 0분에 실행
-  @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
-//  @Scheduled(cron = "0 0 9-20 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 0 9-20 * * *", zone = "Asia/Seoul")
 //  @Scheduled(initialDelay = 0, fixedRate = 60 * 1000 * 60) // 1시간마다 실행 (테스트용)
   public void runCollectBatch() {
     val fcmCandidates = new ArrayList<Alrim>();
@@ -34,7 +33,7 @@ public class AlrimEventBatch {
       val notices = crawler.crawlNotices();
       val noticesWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.NOTICE, notices);
       commandBatchMediator.saveAll(noticesWithoutExisting);
-//      fcmCandidates.addAll(noticesWithoutExisting);
+      fcmCandidates.addAll(noticesWithoutExisting);
 
       log.info("공지사항 배치 저장 완료 {}", noticesWithoutExisting.size());
     } catch (Exception e) {
@@ -46,7 +45,7 @@ public class AlrimEventBatch {
       val patchNotes = crawler.crawlPatchNotes();
       val patchNotesWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.PATCH_NOTE, patchNotes);
       commandBatchMediator.saveAll(patchNotesWithoutExisting);
-//      fcmCandidates.addAll(patchNotesWithoutExisting);
+      fcmCandidates.addAll(patchNotesWithoutExisting);
 
       log.info("패치노트 배치 저장 완료 {}", patchNotesWithoutExisting.size());
     } catch (Exception e) {
@@ -58,7 +57,7 @@ public class AlrimEventBatch {
       val events = crawler.crawlEvents();
       val eventsWithoutExisting = mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.EVENT, events);
       commandBatchMediator.saveAll(eventsWithoutExisting);
-//      fcmCandidates.addAll(eventsWithoutExisting.stream().filter(it -> !it.getOutdated()).toList());
+      fcmCandidates.addAll(eventsWithoutExisting.stream().filter(it -> !it.getOutdated()).toList());
 
       // 종료 상태 반영 및 누락된 진행중 이벤트 종료 처리
       mapleLandAlrimBatchService.syncEventOutdatedStatusFromCrawl(events);

--- a/src/main/java/com/maple/api/alrim/application/command/LegacyAlrimCrawler.java
+++ b/src/main/java/com/maple/api/alrim/application/command/LegacyAlrimCrawler.java
@@ -1,0 +1,86 @@
+package com.maple.api.alrim.application.command;
+
+import com.maple.api.alrim.domain.Alrim;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component("legacyAlrimCrawler")
+public class LegacyAlrimCrawler implements AlrimCrawler {
+  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+  private static final String BASE_URL = "https://public.maple.land";
+
+  @Override
+  public List<Alrim> crawlNotices() throws IOException {
+    String url = BASE_URL + "/notice";
+    Document doc = Jsoup.connect(url)
+      .userAgent("Mozilla/5.0")
+      .get();
+
+    return doc.select("div.notion-collection-item")
+      .stream().map(el -> {
+        String link = el.selectFirst("a").attr("href");
+        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
+        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
+
+        return Alrim.createNotice(
+          title,
+          LocalDateTime.parse(date, FORMATTER).plusHours(9),
+          BASE_URL + link
+        );
+      })
+      .filter(it -> it.getTitle().length() >= 10)
+      .toList();
+  }
+
+  @Override
+  public List<Alrim> crawlPatchNotes() throws IOException {
+    String url = BASE_URL + "/update";
+    Document doc = Jsoup.connect(url)
+      .userAgent("Mozilla/5.0")
+      .get();
+
+    return doc.select("div.notion-collection-item")
+      .stream().map(el -> {
+        String link = el.selectFirst("a").attr("href");
+        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
+        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
+
+        return Alrim.createPatchNote(
+          title,
+          LocalDateTime.parse(date, FORMATTER).plusHours(9),
+          BASE_URL + link
+        );
+      })
+      .filter(it -> it.getTitle().length() >= 10)
+      .toList();
+  }
+
+  @Override
+  public List<Alrim> crawlEvents() throws IOException {
+    String url = BASE_URL + "/events";
+    Document doc = Jsoup.connect(url)
+      .userAgent("Mozilla/5.0")
+      .get();
+
+    return doc.select("div.notion-collection-item")
+      .stream().map(el -> {
+        String link = el.selectFirst("a").attr("href");
+        String title = el.selectFirst("a").selectFirst("div:nth-of-type(1) > div:nth-of-type(2)").text();
+        String date = el.selectFirst("a").selectFirst("div:nth-of-type(2) > div").text();
+
+        return Alrim.createEvents(
+          title,
+          LocalDateTime.parse(date, FORMATTER).plusHours(9),
+          BASE_URL + link
+        );
+      })
+      .filter(it -> it.getTitle().length() >= 10)
+      .toList();
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/command/MaplelandAlrimBatchService.java
+++ b/src/main/java/com/maple/api/alrim/application/command/MaplelandAlrimBatchService.java
@@ -1,0 +1,94 @@
+package com.maple.api.alrim.application.command;
+
+import com.maple.api.alrim.domain.Alrim;
+import com.maple.api.alrim.domain.AlrimType;
+import com.maple.api.alrim.repository.AlrimRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MaplelandAlrimBatchService {
+  private final AlrimRepository alrimRepository;
+
+  @Transactional(readOnly = true)
+  public List<Alrim> excludeExistingFromCrawledAlrims(AlrimType alrimType, List<Alrim> crawledAlrims) {
+    if (crawledAlrims.isEmpty()) {
+      return List.of();
+    }
+
+    Set<String> crawledLinks = extractLinks(crawledAlrims);
+    Set<String> existingLinks = findExistingLinks(alrimType, crawledLinks);
+
+    return exculdeExisting(crawledAlrims, existingLinks);
+  }
+
+  private Set<String> extractLinks(List<Alrim> alrims) {
+    return alrims.stream()
+            .map(Alrim::getLink)
+            .collect(Collectors.toSet());
+  }
+
+  private Set<String> findExistingLinks(AlrimType alrimType, Set<String> crawledLinks) {
+    return alrimRepository.findAllByTypeAndLinkIn(alrimType, crawledLinks)
+            .stream()
+            .map(Alrim::getLink)
+            .collect(Collectors.toSet());
+  }
+
+  private List<Alrim> exculdeExisting(List<Alrim> crawledAlrims, Set<String> existingLinks) {
+    return crawledAlrims.stream()
+            .filter(alrim -> !existingLinks.contains(alrim.getLink()))
+            .toList();
+  }
+
+  @Transactional
+  public void syncEventOutdatedStatusFromCrawl(List<Alrim> crawledEvents) {
+    Map<String, Boolean> crawledOutdatedByLink = mapOutdatedByLink(crawledEvents);
+
+    synchronizeExistingEventOutdated(crawledOutdatedByLink);
+    markMissingOngoingEventsAsOutdated(crawledOutdatedByLink);
+  }
+
+  private Map<String, Boolean> mapOutdatedByLink(List<Alrim> crawledEvents) {
+    return crawledEvents.stream()
+      .collect(Collectors.toMap(Alrim::getLink, Alrim::getOutdated, (left, right) -> right));
+  }
+
+  private void synchronizeExistingEventOutdated(Map<String, Boolean> crawledOutdatedByLink) {
+    alrimRepository.findAllByTypeAndLinkIn(AlrimType.EVENT, crawledOutdatedByLink.keySet())
+      .forEach(savedEvent -> updateOutdatedStatusIfChanged(savedEvent, crawledOutdatedByLink));
+  }
+
+  private void updateOutdatedStatusIfChanged(Alrim savedEvent, Map<String, Boolean> crawledOutdatedByLink) {
+    Boolean crawledOutdated = crawledOutdatedByLink.get(savedEvent.getLink());
+    if (crawledOutdated == null || savedEvent.getOutdated().equals(crawledOutdated)) {
+      return;
+    }
+
+    savedEvent.setOutdated(crawledOutdated);
+    alrimRepository.save(savedEvent);
+  }
+
+  private void markMissingOngoingEventsAsOutdated(Map<String, Boolean> crawledOutdatedByLink) {
+    alrimRepository.findAllByOutdatedIsFalseAndTypeOrderByDateDesc(AlrimType.EVENT)
+      .stream()
+      .filter(savedEvent -> isMissingFromCrawledEvents(savedEvent, crawledOutdatedByLink))
+      .forEach(this::markAsOutdated);
+  }
+
+  private boolean isMissingFromCrawledEvents(Alrim savedEvent, Map<String, Boolean> crawledOutdatedByLink) {
+    return !crawledOutdatedByLink.containsKey(savedEvent.getLink());
+  }
+
+  private void markAsOutdated(Alrim alrim) {
+    alrim.setOutdated(true);
+    alrimRepository.save(alrim);
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/command/MaplelandAlrimCrawler.java
+++ b/src/main/java/com/maple/api/alrim/application/command/MaplelandAlrimCrawler.java
@@ -1,0 +1,170 @@
+package com.maple.api.alrim.application.command;
+
+import com.maple.api.alrim.domain.Alrim;
+import com.maple.api.alrim.domain.AlrimType;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+@Primary
+@Component
+public class MaplelandAlrimCrawler implements AlrimCrawler {
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+  private static final Pattern DATE_PATTERN = Pattern.compile("\\d{4}\\.\\d{2}\\.\\d{2}");
+  private static final String BASE_URL = "https://maple.land";
+  private static final String NOTICES_PATH = "/board/notices";
+  private static final Pattern NOTICE_LINK_PATTERN = Pattern.compile("^/board/notices/[a-z0-9]+$");
+  private static final String EVENTS_PATH = "/board/events";
+  private static final Pattern EVENT_LINK_PATTERN = Pattern.compile("^/board/events/[a-z0-9]+$");
+
+  @Override
+  public List<Alrim> crawlNotices() throws IOException {
+    return crawlAllPages(NOTICES_PATH, html ->
+      parseNoticeBoard(html, category -> !"업데이트".equals(category), AlrimType.NOTICE)
+    );
+  }
+
+  @Override
+  public List<Alrim> crawlPatchNotes() throws IOException {
+    return crawlAllPages(NOTICES_PATH, html ->
+      parseNoticeBoard(html, "업데이트"::equals, AlrimType.PATCH_NOTE)
+    );
+  }
+
+  @Override
+  public List<Alrim> crawlEvents() throws IOException {
+    return crawlAllPages(EVENTS_PATH, this::parseEvents);
+  }
+
+  List<Alrim> parseNotices(String html) {
+    return parseNoticeBoard(html, category -> !"업데이트".equals(category), AlrimType.NOTICE);
+  }
+
+  List<Alrim> parsePatchNotes(String html) {
+    return parseNoticeBoard(html, "업데이트"::equals, AlrimType.PATCH_NOTE);
+  }
+
+  List<Alrim> parseEvents(String html) {
+    return parseEventBoard(html);
+  }
+
+  private List<Alrim> parseNoticeBoard(String html, Predicate<String> categoryFilter, AlrimType type) {
+    Document doc = Jsoup.parse(html, BASE_URL);
+    return doc.select("a[href]")
+      .stream()
+      .filter(anchor -> NOTICE_LINK_PATTERN.matcher(anchor.attr("href")).matches())
+      .map(anchor -> toBoardRow(anchor, type))
+      .filter(row -> row != null && categoryFilter.test(row.category()))
+      .map(this::toAlrim)
+      .toList();
+  }
+
+  private List<Alrim> parseEventBoard(String html) {
+    Document doc = Jsoup.parse(html, BASE_URL);
+    return doc.select("a[href]")
+      .stream()
+      .filter(anchor -> EVENT_LINK_PATTERN.matcher(anchor.attr("href")).matches())
+      .map(anchor -> toBoardRow(anchor, AlrimType.EVENT))
+      .filter(row -> row != null && isSupportedEventCategory(row.category()))
+      .map(this::toAlrim)
+      .toList();
+  }
+
+  private BoardRow toBoardRow(Element anchor, AlrimType type) {
+    Element row = anchor.parent() != null ? anchor.parent().parent() : null;
+    if (row == null) {
+      return null;
+    }
+
+    Element categoryElement = row.selectFirst("span.inline-flex");
+    String category = categoryElement != null ? categoryElement.text().trim() : "";
+    String title = anchor.text().trim();
+    String link = anchor.absUrl("href");
+
+    var matcher = DATE_PATTERN.matcher(row.text());
+    if (category.isBlank() || title.isBlank() || link.isBlank() || !matcher.find()) {
+      return null;
+    }
+
+    LocalDateTime date = LocalDate.parse(matcher.group(), DATE_FORMATTER).atStartOfDay();
+    return new BoardRow(type, category, title, date, link);
+  }
+
+  private Alrim toAlrim(BoardRow row) {
+    Alrim alrim = switch (row.type()) {
+      case NOTICE -> Alrim.createNotice(row.title(), row.date(), row.link());
+      case PATCH_NOTE -> Alrim.createPatchNote(row.title(), row.date(), row.link());
+      case EVENT -> Alrim.createEvents(row.title(), row.date(), row.link());
+    };
+
+    if (row.type() == AlrimType.EVENT) {
+      alrim.markOutdated("종료".equals(row.category()));
+    }
+
+    return alrim;
+  }
+
+  private boolean isSupportedEventCategory(String category) {
+    return "진행중".equals(category) || "종료".equals(category);
+  }
+
+  private List<Alrim> crawlAllPages(String path, Function<String, List<Alrim>> parser) throws IOException {
+    String firstPageHtml = fetchBoardPage(path);
+    List<Alrim> results = new ArrayList<>(parser.apply(firstPageHtml));
+
+    int lastPage = extractLastPage(Jsoup.parse(firstPageHtml, BASE_URL));
+    for (int page = 2; page <= lastPage; page++) {
+      results.addAll(parser.apply(fetchBoardPage(path + "?page=" + page)));
+    }
+
+    return results;
+  }
+
+  private int extractLastPage(Document doc) {
+    return doc.select("nav[aria-label=페이지 네비게이션] a[href*=page=]")
+      .stream()
+      .map(element -> element.attr("href"))
+      .mapToInt(this::extractPageNumber)
+      .max()
+      .orElse(1);
+  }
+
+  private int extractPageNumber(String href) {
+    int index = href.indexOf("page=");
+    if (index < 0) {
+      return 1;
+    }
+
+    String page = href.substring(index + 5).replaceAll("[^0-9].*$", "");
+    return page.isBlank() ? 1 : Integer.parseInt(page);
+  }
+
+  private String fetchBoardPage(String path) throws IOException {
+    return Jsoup.connect(BASE_URL + path)
+      .userAgent("Mozilla/5.0")
+      .ignoreContentType(true)
+      .execute()
+      .body();
+  }
+
+  private record BoardRow(
+    AlrimType type,
+    String category,
+    String title,
+    LocalDateTime date,
+    String link
+  ) {
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/query/AlrimV2DTO.java
+++ b/src/main/java/com/maple/api/alrim/application/query/AlrimV2DTO.java
@@ -1,0 +1,32 @@
+package com.maple.api.alrim.application.query;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.maple.api.alrim.domain.Alrim;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "알림 정보 v2")
+public record AlrimV2DTO(
+  @Schema(description = "알림 ID")
+  Long id,
+  @Schema(description = "공지사항 패치노트 업데이트")
+  String type,
+  @Schema(description = "제목")
+  String title,
+  @Schema(description = "알림 링크")
+  String link,
+  @Schema(description = "등록일자")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  LocalDateTime date
+) {
+  public static AlrimV2DTO toDTO(Alrim alrim) {
+    return new AlrimV2DTO(
+      alrim.getId(),
+      alrim.getType().getLabel(),
+      alrim.getTitle(),
+      alrim.getLink(),
+      alrim.getDate()
+    );
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/query/AlrimV2DTOWithReadInfo.java
+++ b/src/main/java/com/maple/api/alrim/application/query/AlrimV2DTOWithReadInfo.java
@@ -1,0 +1,18 @@
+package com.maple.api.alrim.application.query;
+
+import com.maple.api.alrim.domain.Alrim;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "전체 알림 정보 v2인데, 읽었는지 여부를 함께")
+public record AlrimV2DTOWithReadInfo(
+  AlrimV2DTO alrim,
+  @Schema(description = "해당 알림을 현재 유저가 읽었는지 여부")
+  boolean alreadyRead
+) {
+  public static AlrimV2DTOWithReadInfo toDTO(Alrim alrim, boolean alreadyRead) {
+    return new AlrimV2DTOWithReadInfo(
+      AlrimV2DTO.toDTO(alrim),
+      alreadyRead
+    );
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/query/AlrimV2QueryService.java
+++ b/src/main/java/com/maple/api/alrim/application/query/AlrimV2QueryService.java
@@ -1,0 +1,55 @@
+package com.maple.api.alrim.application.query;
+
+import com.maple.api.alrim.common.CursorPage;
+import com.maple.api.alrim.domain.Alrim;
+import com.maple.api.alrim.domain.AlrimType;
+import com.maple.api.alrim.repository.AlrimQueryRepository;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AlrimV2QueryService {
+  private final AlrimQueryRepository alrimQueryRepository;
+
+  public AlrimV2QueryService(AlrimQueryRepository alrimQueryRepository) {
+    this.alrimQueryRepository = alrimQueryRepository;
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPage<AlrimV2DTO> findAllNotices(@Nullable Long cursor, int pageSize) {
+    return toCursorPage(
+      alrimQueryRepository.findAllAfterCursor(AlrimType.NOTICE, false, cursor, pageSize)
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPage<AlrimV2DTO> findAllPatchNotes(@Nullable Long cursor, int pageSize) {
+    return toCursorPage(
+      alrimQueryRepository.findAllAfterCursor(AlrimType.PATCH_NOTE, false, cursor, pageSize)
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPage<AlrimV2DTO> findAllOnGoingEvents(@Nullable Long cursor, int pageSize) {
+    return toCursorPage(
+      alrimQueryRepository.findAllAfterCursor(AlrimType.EVENT, false, cursor, pageSize)
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPage<AlrimV2DTO> findAllOutDatedEvents(@Nullable Long cursor, int pageSize) {
+    return toCursorPage(
+      alrimQueryRepository.findAllAfterCursor(AlrimType.EVENT, true, cursor, pageSize)
+    );
+  }
+
+  private CursorPage<AlrimV2DTO> toCursorPage(CursorPage<Alrim> alrimPage) {
+    return new CursorPage<>(
+      alrimPage.getContents().stream()
+        .map(AlrimV2DTO::toDTO)
+        .toList(),
+      alrimPage.getHasMore()
+    );
+  }
+}

--- a/src/main/java/com/maple/api/alrim/application/query/AlrimV2QueryService.java
+++ b/src/main/java/com/maple/api/alrim/application/query/AlrimV2QueryService.java
@@ -2,18 +2,52 @@ package com.maple.api.alrim.application.query;
 
 import com.maple.api.alrim.common.CursorPage;
 import com.maple.api.alrim.domain.Alrim;
+import com.maple.api.alrim.domain.AlrimRead;
 import com.maple.api.alrim.domain.AlrimType;
 import com.maple.api.alrim.repository.AlrimQueryRepository;
+import com.maple.api.alrim.repository.AlrimReadRepository;
+import lombok.val;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.stream.Collectors;
+
 @Service
 public class AlrimV2QueryService {
   private final AlrimQueryRepository alrimQueryRepository;
+  private final AlrimReadRepository alrimReadRepository;
 
-  public AlrimV2QueryService(AlrimQueryRepository alrimQueryRepository) {
+  public AlrimV2QueryService(
+    AlrimQueryRepository alrimQueryRepository,
+    AlrimReadRepository alrimReadRepository
+  ) {
     this.alrimQueryRepository = alrimQueryRepository;
+    this.alrimReadRepository = alrimReadRepository;
+  }
+
+  @Transactional(readOnly = true)
+  public CursorPage<AlrimV2DTOWithReadInfo> findAllForAlrimForMemberWithCursor(
+    String memberId,
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<Alrim> alrimPage = alrimQueryRepository.findAllAfterCursor(cursor, pageSize);
+
+    val alreadyReadSet = alrimReadRepository.findAllByMemberIdAndAlrimIdIn(
+        memberId,
+        alrimPage.getContents().stream().map(Alrim::getId).toList()
+      )
+      .stream()
+      .map(AlrimRead::getAlrimId)
+      .collect(Collectors.toSet());
+
+    return new CursorPage<>(
+      alrimPage.getContents().stream()
+        .map(it -> AlrimV2DTOWithReadInfo.toDTO(it, alreadyReadSet.contains(it.getId())))
+        .toList(),
+      alrimPage.getHasMore()
+    );
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/maple/api/alrim/domain/Alrim.java
+++ b/src/main/java/com/maple/api/alrim/domain/Alrim.java
@@ -62,4 +62,8 @@ public class Alrim extends BaseEntity {
       null, AlrimType.EVENT, title, date, link, false
     );
   }
+
+  public void markOutdated(boolean outdated) {
+    this.outdated = outdated;
+  }
 }

--- a/src/main/java/com/maple/api/alrim/domain/AlrimRead.java
+++ b/src/main/java/com/maple/api/alrim/domain/AlrimRead.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "alrim_read", indexes = {
   @Index(name = "idx_alrim_read_member_id_alrim_link", columnList = "memberId, alrimLink"),
+  @Index(name = "idx_alrim_read_member_id_alrim_id", columnList = "memberId, alrimId"),
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,10 +24,18 @@ public class AlrimRead {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  private Long alrimId;
   private String alrimLink;
   private String memberId;
 
   public AlrimRead(String alrimLink, String memberId) {
+    this.alrimId = null;
+    this.alrimLink = alrimLink;
+    this.memberId = memberId;
+  }
+
+  public AlrimRead(Long alrimId, String alrimLink, String memberId) {
+    this.alrimId = alrimId;
     this.alrimLink = alrimLink;
     this.memberId = memberId;
   }

--- a/src/main/java/com/maple/api/alrim/domain/AlrimRead.java
+++ b/src/main/java/com/maple/api/alrim/domain/AlrimRead.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "alrim_read", indexes = {
   @Index(name = "idx_alrim_read_member_id_alrim_link", columnList = "memberId, alrimLink"),
-  @Index(name = "idx_alrim_read_member_id_alrim_id", columnList = "memberId, alrimId"),
+  @Index(name = "idx_alrim_read_member_id_alrim_id", columnList = "memberId, alrimId", unique = true),
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/maple/api/alrim/exception/AlrimException.java
+++ b/src/main/java/com/maple/api/alrim/exception/AlrimException.java
@@ -1,0 +1,15 @@
+package com.maple.api.alrim.exception;
+
+import com.maple.api.common.presentation.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlrimException implements ExceptionCode {
+  ALRIM_NOT_FOUND("알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/maple/api/alrim/presentation/restapi/AlrimV2Controller.java
+++ b/src/main/java/com/maple/api/alrim/presentation/restapi/AlrimV2Controller.java
@@ -1,0 +1,57 @@
+package com.maple.api.alrim.presentation.restapi;
+
+import com.maple.api.alrim.application.query.AlrimV2DTO;
+import com.maple.api.alrim.application.query.AlrimV2QueryService;
+import com.maple.api.alrim.common.CursorPage;
+import com.maple.api.common.presentation.restapi.ResponseTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/alrim")
+public class AlrimV2Controller {
+  private final AlrimV2QueryService queryService;
+
+  public AlrimV2Controller(AlrimV2QueryService queryService) {
+    this.queryService = queryService;
+  }
+
+  @GetMapping("/list/notices")
+  public ResponseEntity<ResponseTemplate<CursorPage<AlrimV2DTO>>> getAllNotices(
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<AlrimV2DTO> result = queryService.findAllNotices(cursor, pageSize);
+    return ResponseEntity.ok(ResponseTemplate.success(result));
+  }
+
+  @GetMapping("/list/patch-notes")
+  public ResponseEntity<ResponseTemplate<CursorPage<AlrimV2DTO>>> getAllPatchNotes(
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<AlrimV2DTO> result = queryService.findAllPatchNotes(cursor, pageSize);
+    return ResponseEntity.ok(ResponseTemplate.success(result));
+  }
+
+  @GetMapping("/list/events/ongoing")
+  public ResponseEntity<ResponseTemplate<CursorPage<AlrimV2DTO>>> getOngoingEvents(
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<AlrimV2DTO> result = queryService.findAllOnGoingEvents(cursor, pageSize);
+    return ResponseEntity.ok(ResponseTemplate.success(result));
+  }
+
+  @GetMapping("/list/events/outdated")
+  public ResponseEntity<ResponseTemplate<CursorPage<AlrimV2DTO>>> getOutdatedEvents(
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<AlrimV2DTO> result = queryService.findAllOutDatedEvents(cursor, pageSize);
+    return ResponseEntity.ok(ResponseTemplate.success(result));
+  }
+}

--- a/src/main/java/com/maple/api/alrim/presentation/restapi/AlrimV2Controller.java
+++ b/src/main/java/com/maple/api/alrim/presentation/restapi/AlrimV2Controller.java
@@ -1,11 +1,14 @@
 package com.maple.api.alrim.presentation.restapi;
 
 import com.maple.api.alrim.application.query.AlrimV2DTO;
+import com.maple.api.alrim.application.query.AlrimV2DTOWithReadInfo;
 import com.maple.api.alrim.application.query.AlrimV2QueryService;
 import com.maple.api.alrim.common.CursorPage;
+import com.maple.api.auth.domain.PrincipalDetails;
 import com.maple.api.common.presentation.restapi.ResponseTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +20,20 @@ public class AlrimV2Controller {
 
   public AlrimV2Controller(AlrimV2QueryService queryService) {
     this.queryService = queryService;
+  }
+
+  @GetMapping("/all")
+  public ResponseEntity<ResponseTemplate<CursorPage<AlrimV2DTOWithReadInfo>>> getAllAlrim(
+    @AuthenticationPrincipal PrincipalDetails principalDetails,
+    @Nullable Long cursor,
+    int pageSize
+  ) {
+    CursorPage<AlrimV2DTOWithReadInfo> result = queryService.findAllForAlrimForMemberWithCursor(
+      principalDetails.getProviderId(),
+      cursor,
+      pageSize
+    );
+    return ResponseEntity.ok(ResponseTemplate.success(result));
   }
 
   @GetMapping("/list/notices")

--- a/src/main/java/com/maple/api/alrim/repository/AlrimQueryRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimQueryRepository.java
@@ -42,6 +42,37 @@ public class AlrimQueryRepository {
   }
 
   public CursorPage<Alrim> findAllAfterCursor(
+    @Nullable Long cursorId,
+    int pageSize
+  ) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (cursorId != null) {
+      Alrim cursorAlrim = queryFactory.selectFrom(alrim)
+        .where(alrim.id.eq(cursorId))
+        .fetchOne();
+
+      if (cursorAlrim == null) {
+        return new CursorPage<>(List.of(), false);
+      }
+
+      builder.and(
+        alrim.date.lt(cursorAlrim.getDate())
+          .or(alrim.date.eq(cursorAlrim.getDate()).and(alrim.id.lt(cursorAlrim.getId())))
+      );
+    }
+
+    val results = queryFactory.selectFrom(alrim)
+      .where(builder)
+      .orderBy(alrim.date.desc(), alrim.id.desc())
+      .limit(pageSize + 1)
+      .fetch();
+
+    boolean hasMore = results.size() > pageSize;
+    return new CursorPage<>(hasMore ? results.subList(0, pageSize) : results, hasMore);
+  }
+
+  public CursorPage<Alrim> findAllAfterCursor(
     AlrimType alrimType,
     boolean isOutdated,
     @Nullable LocalDateTime cursor,

--- a/src/main/java/com/maple/api/alrim/repository/AlrimQueryRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimQueryRepository.java
@@ -12,6 +12,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -58,6 +59,42 @@ public class AlrimQueryRepository {
     val results = queryFactory.selectFrom(alrim)
       .where(builder)
       .orderBy(alrim.date.desc())
+      .limit(pageSize + 1)
+      .fetch();
+
+    boolean hasMore = results.size() > pageSize;
+    return new CursorPage<>(hasMore ? results.subList(0, pageSize) : results, hasMore);
+  }
+
+  public CursorPage<Alrim> findAllAfterCursor(
+    AlrimType alrimType,
+    boolean isOutdated,
+    @Nullable Long cursorId,
+    int pageSize
+  ) {
+    BooleanBuilder builder = new BooleanBuilder(
+      alrim.type.eq(alrimType)
+        .and(alrim.outdated.eq(isOutdated))
+    );
+
+    if (cursorId != null) {
+      Alrim cursorAlrim = queryFactory.selectFrom(alrim)
+        .where(alrim.id.eq(cursorId))
+        .fetchOne();
+
+      if (cursorAlrim == null) {
+        return new CursorPage<>(List.of(), false);
+      }
+
+      builder.and(
+        alrim.date.lt(cursorAlrim.getDate())
+          .or(alrim.date.eq(cursorAlrim.getDate()).and(alrim.id.lt(cursorAlrim.getId())))
+      );
+    }
+
+    val results = queryFactory.selectFrom(alrim)
+      .where(builder)
+      .orderBy(alrim.date.desc(), alrim.id.desc())
       .limit(pageSize + 1)
       .fetch();
 

--- a/src/main/java/com/maple/api/alrim/repository/AlrimReadRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimReadRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface AlrimReadRepository extends JpaRepository<AlrimRead, Long> {
   List<AlrimRead> findAllByMemberIdAndAlrimLinkIn(String memberId, List<String> alrimLinks);
+  List<AlrimRead> findAllByMemberIdAndAlrimIdIn(String memberId, List<Long> alrimIds);
 }

--- a/src/main/java/com/maple/api/alrim/repository/AlrimReadRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimReadRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface AlrimReadRepository extends JpaRepository<AlrimRead, Long> {
   List<AlrimRead> findAllByMemberIdAndAlrimLinkIn(String memberId, List<String> alrimLinks);
   List<AlrimRead> findAllByMemberIdAndAlrimIdIn(String memberId, List<Long> alrimIds);
+  boolean existsByMemberIdAndAlrimId(String memberId, Long alrimId);
 }

--- a/src/main/java/com/maple/api/alrim/repository/AlrimRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimRepository.java
@@ -27,4 +27,5 @@ public interface AlrimRepository extends JpaRepository<Alrim, Long> {
   List<Alrim> findAllByTypeAndDateAfterOrderByDateDesc(AlrimType type, LocalDateTime dateTime);
 
   List<Alrim> findAllByTypeAndLinkIn(AlrimType type, Collection<String> links);
+  Optional<Alrim> findByLink(String link);
 }

--- a/src/main/java/com/maple/api/alrim/repository/AlrimRepository.java
+++ b/src/main/java/com/maple/api/alrim/repository/AlrimRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,4 +25,6 @@ public interface AlrimRepository extends JpaRepository<Alrim, Long> {
 
   // 타입별 알림 보기
   List<Alrim> findAllByTypeAndDateAfterOrderByDateDesc(AlrimType type, LocalDateTime dateTime);
+
+  List<Alrim> findAllByTypeAndLinkIn(AlrimType type, Collection<String> links);
 }

--- a/src/main/java/com/maple/api/common/presentation/config/SecurityConfig.java
+++ b/src/main/java/com/maple/api/common/presentation/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
           .requestMatchers("/api/v1/categories/**").permitAll()
           .requestMatchers("/api/v1/jobs/**").permitAll()
           .requestMatchers("/api/v1/alrim/list/**").permitAll()
+          .requestMatchers("/api/v2/alrim/list/**").permitAll()
           .anyRequest().authenticated()
       )
       .with(jwtSecurityAdapter, Customizer.withDefaults());

--- a/src/test/java/com/maple/api/alrim/application/command/AlrimEventBatchTest.java
+++ b/src/test/java/com/maple/api/alrim/application/command/AlrimEventBatchTest.java
@@ -9,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +24,9 @@ class AlrimEventBatchTest {
   private AlrimCommandMediator commandBatchMediator;
 
   @Mock
+  private MaplelandAlrimBatchService mapleLandAlrimBatchService;
+
+  @Mock
   private AlrimCrawler crawler;
 
   @Mock
@@ -37,33 +39,32 @@ class AlrimEventBatchTest {
   @DisplayName("batch 테스트")
   void batchTest() throws Exception {
     // given
-    LocalDateTime now = LocalDateTime.now();
+    Alrim notice = Alrim.createNotice("제목 공지사항", java.time.LocalDateTime.now(), "링크 공지사항");
+    Alrim patchNote = Alrim.createPatchNote("패치노트 제목", java.time.LocalDateTime.now(), "링크 패치노트");
+    Alrim ongoingEvent = Alrim.createEvents("진행중 이벤트", java.time.LocalDateTime.now(), "링크 진행중 이벤트");
+    Alrim endedEvent = Alrim.createEvents("종료 이벤트", java.time.LocalDateTime.now(), "링크 종료 이벤트");
+    endedEvent.markOutdated(true);
 
     // 공지
-    given(commandBatchMediator.getRecentCreatedAt(AlrimType.NOTICE)).willReturn(now.minusDays(1));
-    given(crawler.crawlNotices()).willReturn(List.of(
-      Alrim.createNotice("제목 공지사항", now, "링크 공지사항")
-    ));
+    given(crawler.crawlNotices()).willReturn(List.of(notice));
+    given(mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.NOTICE, List.of(notice))).willReturn(List.of(notice));
 
     // 패치노트
-    given(commandBatchMediator.getRecentCreatedAt(AlrimType.PATCH_NOTE)).willReturn(now.minusDays(1));
-    given(crawler.crawlPatchNotes()).willReturn(List.of(
-      Alrim.createPatchNote("패치노트 제목", now, "링크 패치노트")
-    ));
+    given(crawler.crawlPatchNotes()).willReturn(List.of(patchNote));
+    given(mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.PATCH_NOTE, List.of(patchNote))).willReturn(List.of(patchNote));
 
 
     // 이벤트
-    given(commandBatchMediator.getRecentCreatedAt(AlrimType.EVENT)).willReturn(now.minusDays(1));
-    given(crawler.crawlEvents()).willReturn(List.of(
-      Alrim.createEvents("이벤트", now, "링크 이벤트")
-    ));
+    given(crawler.crawlEvents()).willReturn(List.of(ongoingEvent, endedEvent));
+    given(mapleLandAlrimBatchService.excludeExistingFromCrawledAlrims(AlrimType.EVENT, List.of(ongoingEvent, endedEvent)))
+      .willReturn(List.of(ongoingEvent, endedEvent));
 
     // when
     batch.runCollectBatch();
 
     // then
     verify(commandBatchMediator, times(3)).saveAll(anyList());
+    verify(mapleLandAlrimBatchService).syncEventOutdatedStatusFromCrawl(List.of(ongoingEvent, endedEvent));
     verify(alrimFcmManager).sendFcmMessage(any());
   }
 }
-

--- a/src/test/java/com/maple/api/scheduler/NoticeApiTest.java
+++ b/src/test/java/com/maple/api/scheduler/NoticeApiTest.java
@@ -1,6 +1,7 @@
 package com.maple.api.scheduler;
 
 import com.maple.api.alrim.application.command.AlrimCrawler;
+import com.maple.api.alrim.application.command.MaplelandAlrimCrawler;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,25 +11,25 @@ public class NoticeApiTest {
 
   @Test
   public void 공지사항테스트() throws Exception {
-    AlrimCrawler crawler = new AlrimCrawler();
+    AlrimCrawler crawler = new MaplelandAlrimCrawler();
     var result = crawler.crawlNotices();
 
-    assertThat(result.size()).isGreaterThan(0); // 명시적으로 길이 확인
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void 패치노트테스트() throws Exception {
-    AlrimCrawler crawler = new AlrimCrawler();
+    AlrimCrawler crawler = new MaplelandAlrimCrawler();
     var result = crawler.crawlPatchNotes();
 
-    assertThat(result.size()).isGreaterThan(0); // 명시적으로 길이 확인
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void 진행중이벤트테스트() throws Exception {
-    AlrimCrawler crawler = new AlrimCrawler();
+    AlrimCrawler crawler = new MaplelandAlrimCrawler();
     var result = crawler.crawlEvents();
 
-    assertThat(result.size()).isGreaterThan(0); // 명시적으로 길이 확인
+    assertThat(result).isNotNull();
   }
 }


### PR DESCRIPTION
## 요약
- 크롤러가 변경된 공식 사이트에 맞게 수정되었습니다.
- Alrim 관련 API가 AlrimLink가 아닌 ID 기반으로 조작할 수 있도록 수정했습니다.

## 구현 내용 사항
- AlrimCrawler 이름을 인터페이스로 전환하고, 기존 크롤러는 LegacyAlrimCrawler, 새로운 크롤러는 MaplelandAlrimCrawler로 변경 후 새로운 크롤러를 사용하도록 했습니다.
- Alrim 배치가 동작할 때, 전체 게시글을 크롤링하고 Alrim에 없는 걸 추가하는 방식으로 로직을 변경했습니다.
- Alrim V2 Controller를 구현했습니다. 해당 API는 응답에 ID를 추가하고 커서 페이징 시 id를 기반으로 페이징 하도록 변경했습니다. (내부적으로는 datetime + id를 커서로 사용합니다.)