### PR TITLE
feat: 아이템 직업 필터·상세를 계열(item_categories) 기반으로 전환

### DIFF
--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
@@ -4,13 +4,13 @@ import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
 import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
 import com.maple.api.bookmark.application.dto.MonsterBookmarkSearchRequestDto;
 import com.maple.api.bookmark.domain.BookmarkType;
-import com.maple.api.job.domain.Job;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +22,13 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.maple.api.bookmark.domain.QBookmark.bookmark;
 import static com.maple.api.bookmark.domain.QBookmarkCollection.bookmarkCollection;
 import static com.maple.api.item.domain.QEquipmentItem.equipmentItem;
 import static com.maple.api.item.domain.QItem.item;
-import static com.maple.api.item.domain.QItemJob.itemJob;
+import static com.maple.api.item.domain.QItemCategory.itemCategory;
 import static com.maple.api.map.domain.QMap.map;
 import static com.maple.api.monster.domain.QMonster.monster;
 import static com.maple.api.npc.domain.QNpc.npc;
@@ -165,11 +166,24 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
                 .and(bookmark.bookmarkType.eq(BookmarkType.ITEM));
 
         if (request.jobIds() != null && !request.jobIds().isEmpty()) {
-            builder.and(
-                    new BooleanBuilder()
-                            .or(itemJob.jobId.in(request.jobIds()))
-                            .or(itemJob.jobId.eq(Job.COMMON_JOB_ID))
-            );
+            List<Integer> categoryIds = request.jobIds().stream()
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            if (!categoryIds.isEmpty()) {
+                builder.and(
+                        new BooleanBuilder()
+                                .or(JPAExpressions.selectOne()
+                                        .from(itemCategory)
+                                        .where(itemCategory.itemId.eq(item.itemId)
+                                                .and(itemCategory.categoryId.in(categoryIds)))
+                                        .exists())
+                                .or(JPAExpressions.selectOne()
+                                        .from(itemCategory)
+                                        .where(itemCategory.itemId.eq(item.itemId))
+                                        .notExists())
+                );
+            }
         }
         if (request.minLevel() != null) {
             builder.and(equipmentItem.requiredStats.level.goe(request.minLevel()));
@@ -190,7 +204,6 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
                 .from(bookmark)
                 .join(item).on(bookmark.resourceId.eq(item.itemId))
                 .leftJoin(equipmentItem).on(item.itemId.eq(equipmentItem.itemId))
-                .leftJoin(itemJob).on(item.itemId.eq(itemJob.itemId))
                 .where(where)
                 .groupBy(bookmark.bookmarkId)
                 .orderBy(order.toArray(new OrderSpecifier[0]))
@@ -222,7 +235,6 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
                 .from(bookmark)
                 .join(item).on(bookmark.resourceId.eq(item.itemId))
                 .leftJoin(equipmentItem).on(item.itemId.eq(equipmentItem.itemId))
-                .leftJoin(itemJob).on(item.itemId.eq(itemJob.itemId))
                 .where(where);
     }
 

--- a/src/main/java/com/maple/api/item/domain/ItemCategory.java
+++ b/src/main/java/com/maple/api/item/domain/ItemCategory.java
@@ -1,7 +1,11 @@
 package com.maple.api.item.domain;
 
-import com.maple.api.common.domain.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +14,10 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "items_job")
+@Table(name = "item_categories")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ItemJob extends BaseEntity {
+public class ItemCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,8 +26,8 @@ public class ItemJob extends BaseEntity {
     @Column(name = "item_id")
     private Integer itemId;
 
-    @Column(name = "job_id")
-    private Integer jobId;
+    @Column(name = "category_id")
+    private Integer categoryId;
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/src/main/java/com/maple/api/item/repository/ItemQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/item/repository/ItemQueryDslRepositoryImpl.java
@@ -3,13 +3,13 @@ package com.maple.api.item.repository;
 import com.maple.api.item.application.dto.ItemMonsterDropDto;
 import com.maple.api.item.application.dto.ItemSearchRequestDto;
 import com.maple.api.item.domain.Item;
-import com.maple.api.job.domain.Job;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static com.maple.api.item.domain.QEquipmentItem.equipmentItem;
 import static com.maple.api.item.domain.QItem.item;
-import static com.maple.api.item.domain.QItemJob.itemJob;
+import static com.maple.api.item.domain.QItemCategory.itemCategory;
 import static com.maple.api.monster.domain.QItemMonsterDrop.itemMonsterDrop;
 import static com.maple.api.monster.domain.QMonster.monster;
 
@@ -79,15 +79,24 @@ public class ItemQueryDslRepositoryImpl implements ItemQueryDslRepository {
             builder.and(item.nameKr.containsIgnoreCase(request.keyword().trim()));
         }
         if (request.jobIds() != null && !request.jobIds().isEmpty()) {
-            List<Integer> jobIds = request.jobIds().stream()
+            List<Integer> categoryIds = request.jobIds().stream()
                     .filter(Objects::nonNull)
                     .toList();
 
-            builder.and(
-                new BooleanBuilder()
-                    .or(itemJob.jobId.in(jobIds))
-                    .or(itemJob.jobId.eq(Job.COMMON_JOB_ID))
-            );
+            if (!categoryIds.isEmpty()) {
+                builder.and(
+                    new BooleanBuilder()
+                        .or(JPAExpressions.selectOne()
+                                .from(itemCategory)
+                                .where(itemCategory.itemId.eq(item.itemId)
+                                        .and(itemCategory.categoryId.in(categoryIds)))
+                                .exists())
+                        .or(JPAExpressions.selectOne()
+                                .from(itemCategory)
+                                .where(itemCategory.itemId.eq(item.itemId))
+                                .notExists())
+                );
+            }
         }
         if (request.minLevel() != null) {
             builder.and(equipmentItem.requiredStats.level.goe(request.minLevel()));
@@ -124,7 +133,6 @@ public class ItemQueryDslRepositoryImpl implements ItemQueryDslRepository {
                 .select(item.itemId, item.nameKr, equipmentItem.requiredStats.level)
                 .from(item)
                 .leftJoin(equipmentItem).on(item.itemId.eq(equipmentItem.itemId))
-                .leftJoin(itemJob).on(item.itemId.eq(itemJob.itemId))
                 .where(where)
                 .distinct()
                 .offset(pageable.getOffset())
@@ -151,7 +159,6 @@ public class ItemQueryDslRepositoryImpl implements ItemQueryDslRepository {
                 .select(item.countDistinct())
                 .from(item)
                 .leftJoin(equipmentItem).on(item.itemId.eq(equipmentItem.itemId))
-                .leftJoin(itemJob).on(item.itemId.eq(itemJob.itemId))
                 .where(where);
     }
 

--- a/src/main/java/com/maple/api/job/repository/JobRepository.java
+++ b/src/main/java/com/maple/api/job/repository/JobRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface JobRepository extends JpaRepository<Job, Integer> {
     
-    @Query("SELECT j FROM Job j JOIN ItemJob ij ON j.jobId = ij.jobId WHERE ij.itemId = :itemId")
+    @Query("SELECT j FROM Job j JOIN ItemCategory ic ON j.jobId = ic.categoryId WHERE ic.itemId = :itemId")
     List<Job> findByItemId(@Param("itemId") Integer itemId);
 }

--- a/src/test/java/com/maple/api/item/repository/ItemCategoryRepositoryTransitionTest.java
+++ b/src/test/java/com/maple/api/item/repository/ItemCategoryRepositoryTransitionTest.java
@@ -1,0 +1,222 @@
+package com.maple.api.item.repository;
+
+import com.maple.api.bookmark.application.dto.BookmarkSummaryDto;
+import com.maple.api.bookmark.application.dto.ItemBookmarkSearchRequestDto;
+import com.maple.api.bookmark.repository.BookmarkQueryDslRepository;
+import com.maple.api.bookmark.repository.BookmarkQueryDslRepositoryImpl;
+import com.maple.api.common.presentation.config.QueryDslConfig;
+import com.maple.api.item.application.dto.ItemSearchRequestDto;
+import com.maple.api.item.domain.Item;
+import com.maple.api.job.domain.Job;
+import com.maple.api.job.repository.JobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
+@ActiveProfiles("test")
+@Import({QueryDslConfig.class, ItemQueryDslRepositoryImpl.class, BookmarkQueryDslRepositoryImpl.class})
+class ItemCategoryRepositoryTransitionTest {
+
+    private static final Pageable PAGEABLE = PageRequest.of(0, 10);
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ItemQueryDslRepository itemQueryDslRepository;
+
+    @Autowired
+    private BookmarkQueryDslRepository bookmarkQueryDslRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @BeforeEach
+    void setUp() {
+        insertJob(100, "전사");
+        insertJob(200, "법사");
+
+        insertEquipmentItem(7000, "전사 아이템");
+        insertEquipmentItem(7001, "법사 아이템");
+        insertEquipmentItem(7002, "전체착용 아이템");
+
+        insertItemCategory(7000, 100);
+        insertItemCategory(7001, 200);
+
+        jdbcTemplate.update("""
+                INSERT INTO member (
+                    id, provider, nickname, fcm_token,
+                    marketing_agreement, notice_agreement, patch_note_agreement, event_agreement,
+                    level, job_id, profile_image_url, created_at, updated_at
+                )
+                VALUES (?, 'KAKAO', 'tester', '', false, false, false, false, null, null, '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, "member-1");
+
+        insertItemBookmark(7000);
+        insertItemBookmark(7001);
+        insertItemBookmark(7002);
+    }
+
+    @Nested
+    @DisplayName("아이템 검색 직업 필터")
+    class ItemSearchJobFilter {
+
+        @Test
+        @DisplayName("전사 계열과 전체착용 아이템을 반환한다")
+        void searchWarriorCategoryAndCommonItems() {
+            Page<Item> result = itemQueryDslRepository.searchItems(
+                    new ItemSearchRequestDto(null, List.of(100), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(itemIds(result)).containsExactly(7000, 7002);
+        }
+
+        @Test
+        @DisplayName("법사 계열과 전체착용 아이템을 반환한다")
+        void searchMageCategoryAndCommonItems() {
+            Page<Item> result = itemQueryDslRepository.searchItems(
+                    new ItemSearchRequestDto(null, List.of(200), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(itemIds(result)).containsExactly(7001, 7002);
+        }
+
+        @Test
+        @DisplayName("직업 필터가 비어 있으면 전체 아이템을 반환한다")
+        void skipJobFilterWhenJobIdsAreEmpty() {
+            Page<Item> result = itemQueryDslRepository.searchItems(
+                    new ItemSearchRequestDto(null, List.of(), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(itemIds(result)).containsExactly(7000, 7001, 7002);
+        }
+    }
+
+    @Nested
+    @DisplayName("아이템 북마크 직업 필터")
+    class ItemBookmarkJobFilter {
+
+        @Test
+        @DisplayName("전사 계열과 전체착용 아이템 북마크를 반환한다")
+        void searchWarriorCategoryAndCommonBookmarks() {
+            Page<BookmarkSummaryDto> result = bookmarkQueryDslRepository.searchItemBookmarks(
+                    "member-1",
+                    new ItemBookmarkSearchRequestDto(List.of(100), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(bookmarkOriginalIds(result)).containsExactlyInAnyOrder(7000, 7002);
+        }
+
+        @Test
+        @DisplayName("법사 계열과 전체착용 아이템 북마크를 반환한다")
+        void searchMageCategoryAndCommonBookmarks() {
+            Page<BookmarkSummaryDto> result = bookmarkQueryDslRepository.searchItemBookmarks(
+                    "member-1",
+                    new ItemBookmarkSearchRequestDto(List.of(200), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(bookmarkOriginalIds(result)).containsExactlyInAnyOrder(7001, 7002);
+        }
+
+        @Test
+        @DisplayName("직업 필터가 비어 있으면 전체 아이템 북마크를 반환한다")
+        void skipJobFilterWhenJobIdsAreEmpty() {
+            Page<BookmarkSummaryDto> result = bookmarkQueryDslRepository.searchItemBookmarks(
+                    "member-1",
+                    new ItemBookmarkSearchRequestDto(List.of(), null, null, null),
+                    PAGEABLE
+            );
+
+            assertThat(bookmarkOriginalIds(result)).containsExactlyInAnyOrder(7000, 7001, 7002);
+        }
+    }
+
+    @Nested
+    @DisplayName("아이템 상세 직업 목록")
+    class ItemDetailAvailableJobs {
+
+        @Test
+        @DisplayName("계열 아이템은 base 계열 job을 반환한다")
+        void findCategoryJobByItemId() {
+            List<Job> result = jobRepository.findByItemId(7000);
+
+            assertThat(result)
+                    .extracting(Job::getJobId, Job::getJobName)
+                    .containsExactly(tuple(100, "전사"));
+        }
+
+        @Test
+        @DisplayName("전체착용 아이템은 빈 직업 목록을 반환한다")
+        void findNoJobsForCommonItem() {
+            List<Job> result = jobRepository.findByItemId(7002);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    private void insertJob(int jobId, String jobName) {
+        jdbcTemplate.update("""
+                INSERT INTO jobs (job_id, job_name, job_level, disabled, created_at, updated_at)
+                VALUES (?, ?, 1, false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, jobId, jobName);
+    }
+
+    private void insertEquipmentItem(int itemId, String nameKr) {
+        jdbcTemplate.update("""
+                INSERT INTO items (
+                    item_id, item_type, name_kr, name_en, item_image_url,
+                    npc_price, category_id, required_level, created_at, updated_at
+                )
+                VALUES (?, 'EQUIPMENT', ?, ?, '', 0, 1, 10, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, itemId, nameKr, nameKr);
+    }
+
+    private void insertItemCategory(int itemId, int categoryId) {
+        jdbcTemplate.update("""
+                INSERT INTO item_categories (item_id, category_id, created_at)
+                VALUES (?, ?, CURRENT_TIMESTAMP)
+                """, itemId, categoryId);
+    }
+
+    private void insertItemBookmark(int itemId) {
+        jdbcTemplate.update("""
+                INSERT INTO bookmarks (member_id, bookmark_type, resource_id, created_at, updated_at)
+                VALUES ('member-1', 'ITEM', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, itemId);
+    }
+
+    private List<Integer> itemIds(Page<Item> page) {
+        return page.getContent().stream()
+                .map(Item::getItemId)
+                .toList();
+    }
+
+    private List<Integer> bookmarkOriginalIds(Page<BookmarkSummaryDto> page) {
+        return page.getContent().stream()
+                .map(BookmarkSummaryDto::originalId)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 요약
- 아이템 직업 필터와 상세의 착용 가능 직업을 개별 직업(`items_job`) 기준에서 계열(`item_categories`) 기준으로 전환했습니다.
- "공용" 센티넬을 없애고, 계열 제약 행이 없으면 전체 착용으로 처리합니다. 앱 요청/응답 형식은 변경되지 않습니다.

## 구현 내용 사항
- `ItemJob` 엔티티를 `ItemCategory`(`item_categories`)로 전환하고 `items_job` 매핑을 제거했습니다.
- 아이템 검색/북마크 필터를 `item_categories` 기반 `EXISTS / NOT EXISTS`로 변경했습니다. 계열 행이 있으면 매칭하고, 계열 행이 전혀 없으면 전체 착용으로 포함합니다. (요청의 `jobIds`를 그대로 `category_id`로 사용 — 계열 id가 100/200/300/400/500과 동일)
- 아이템 상세의 `availableJobs`를 `ItemCategory ↔ Job` 조인(`job_id = category_id`)으로 조회하도록 변경했습니다. 전체 착용 아이템은 빈 목록으로 내려가며, 앱은 직업 항목을 표시하지 않습니다.
- `Job.COMMON_JOB_ID`는 직업 목록 제외 용도로 유지했습니다.