### PR TITLE
feat: 아이템 직업 조인을 item_jobs(job_category_id) 스키마에 맞춰 정렬

### DIFF
--- a/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/bookmark/repository/BookmarkQueryDslRepositoryImpl.java
@@ -28,7 +28,7 @@ import static com.maple.api.bookmark.domain.QBookmark.bookmark;
 import static com.maple.api.bookmark.domain.QBookmarkCollection.bookmarkCollection;
 import static com.maple.api.item.domain.QEquipmentItem.equipmentItem;
 import static com.maple.api.item.domain.QItem.item;
-import static com.maple.api.item.domain.QItemCategory.itemCategory;
+import static com.maple.api.item.domain.QItemJob.itemJob;
 import static com.maple.api.map.domain.QMap.map;
 import static com.maple.api.monster.domain.QMonster.monster;
 import static com.maple.api.npc.domain.QNpc.npc;
@@ -166,21 +166,21 @@ public class BookmarkQueryDslRepositoryImpl implements BookmarkQueryDslRepositor
                 .and(bookmark.bookmarkType.eq(BookmarkType.ITEM));
 
         if (request.jobIds() != null && !request.jobIds().isEmpty()) {
-            List<Integer> categoryIds = request.jobIds().stream()
+            List<Integer> jobCategoryIds = request.jobIds().stream()
                     .filter(Objects::nonNull)
                     .toList();
 
-            if (!categoryIds.isEmpty()) {
+            if (!jobCategoryIds.isEmpty()) {
                 builder.and(
                         new BooleanBuilder()
                                 .or(JPAExpressions.selectOne()
-                                        .from(itemCategory)
-                                        .where(itemCategory.itemId.eq(item.itemId)
-                                                .and(itemCategory.categoryId.in(categoryIds)))
+                                        .from(itemJob)
+                                        .where(itemJob.itemId.eq(item.itemId)
+                                                .and(itemJob.jobCategoryId.in(jobCategoryIds)))
                                         .exists())
                                 .or(JPAExpressions.selectOne()
-                                        .from(itemCategory)
-                                        .where(itemCategory.itemId.eq(item.itemId))
+                                        .from(itemJob)
+                                        .where(itemJob.itemId.eq(item.itemId))
                                         .notExists())
                 );
             }

--- a/src/main/java/com/maple/api/item/domain/ItemJob.java
+++ b/src/main/java/com/maple/api/item/domain/ItemJob.java
@@ -14,10 +14,10 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "item_categories")
+@Table(name = "item_jobs")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ItemCategory {
+public class ItemJob {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,8 +26,8 @@ public class ItemCategory {
     @Column(name = "item_id")
     private Integer itemId;
 
-    @Column(name = "category_id")
-    private Integer categoryId;
+    @Column(name = "job_category_id")
+    private Integer jobCategoryId;
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/src/main/java/com/maple/api/item/repository/ItemQueryDslRepositoryImpl.java
+++ b/src/main/java/com/maple/api/item/repository/ItemQueryDslRepositoryImpl.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static com.maple.api.item.domain.QEquipmentItem.equipmentItem;
 import static com.maple.api.item.domain.QItem.item;
-import static com.maple.api.item.domain.QItemCategory.itemCategory;
+import static com.maple.api.item.domain.QItemJob.itemJob;
 import static com.maple.api.monster.domain.QItemMonsterDrop.itemMonsterDrop;
 import static com.maple.api.monster.domain.QMonster.monster;
 
@@ -79,21 +79,21 @@ public class ItemQueryDslRepositoryImpl implements ItemQueryDslRepository {
             builder.and(item.nameKr.containsIgnoreCase(request.keyword().trim()));
         }
         if (request.jobIds() != null && !request.jobIds().isEmpty()) {
-            List<Integer> categoryIds = request.jobIds().stream()
+            List<Integer> jobCategoryIds = request.jobIds().stream()
                     .filter(Objects::nonNull)
                     .toList();
 
-            if (!categoryIds.isEmpty()) {
+            if (!jobCategoryIds.isEmpty()) {
                 builder.and(
                     new BooleanBuilder()
                         .or(JPAExpressions.selectOne()
-                                .from(itemCategory)
-                                .where(itemCategory.itemId.eq(item.itemId)
-                                        .and(itemCategory.categoryId.in(categoryIds)))
+                                .from(itemJob)
+                                .where(itemJob.itemId.eq(item.itemId)
+                                        .and(itemJob.jobCategoryId.in(jobCategoryIds)))
                                 .exists())
                         .or(JPAExpressions.selectOne()
-                                .from(itemCategory)
-                                .where(itemCategory.itemId.eq(item.itemId))
+                                .from(itemJob)
+                                .where(itemJob.itemId.eq(item.itemId))
                                 .notExists())
                 );
             }

--- a/src/main/java/com/maple/api/job/repository/JobRepository.java
+++ b/src/main/java/com/maple/api/job/repository/JobRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface JobRepository extends JpaRepository<Job, Integer> {
     
-    @Query("SELECT j FROM Job j JOIN ItemCategory ic ON j.jobId = ic.categoryId WHERE ic.itemId = :itemId")
+    @Query("SELECT j FROM Job j JOIN ItemJob ij ON j.jobId = ij.jobCategoryId WHERE ij.itemId = :itemId")
     List<Job> findByItemId(@Param("itemId") Integer itemId);
 }

--- a/src/test/java/com/maple/api/item/repository/ItemJobRepositoryTransitionTest.java
+++ b/src/test/java/com/maple/api/item/repository/ItemJobRepositoryTransitionTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 })
 @ActiveProfiles("test")
 @Import({QueryDslConfig.class, ItemQueryDslRepositoryImpl.class, BookmarkQueryDslRepositoryImpl.class})
-class ItemCategoryRepositoryTransitionTest {
+class ItemJobRepositoryTransitionTest {
 
     private static final Pageable PAGEABLE = PageRequest.of(0, 10);
 
@@ -58,8 +58,8 @@ class ItemCategoryRepositoryTransitionTest {
         insertEquipmentItem(7001, "법사 아이템");
         insertEquipmentItem(7002, "전체착용 아이템");
 
-        insertItemCategory(7000, 100);
-        insertItemCategory(7001, 200);
+        insertItemJob(7000, 100);
+        insertItemJob(7001, 200);
 
         jdbcTemplate.update("""
                 INSERT INTO member (
@@ -194,11 +194,11 @@ class ItemCategoryRepositoryTransitionTest {
                 """, itemId, nameKr, nameKr);
     }
 
-    private void insertItemCategory(int itemId, int categoryId) {
+    private void insertItemJob(int itemId, int jobCategoryId) {
         jdbcTemplate.update("""
-                INSERT INTO item_categories (item_id, category_id, created_at)
+                INSERT INTO item_jobs (item_id, job_category_id, created_at)
                 VALUES (?, ?, CURRENT_TIMESTAMP)
-                """, itemId, categoryId);
+                """, itemId, jobCategoryId);
     }
 
     private void insertItemBookmark(int itemId) {


### PR DESCRIPTION
## 요약
- mapleland에서 조인 테이블을 `item_categories(category_id)` → `item_jobs(job_category_id)`로 리네임한 것에 맞춰 MLS-BE 매핑·쿼리를 정렬했습니다.
- 순수 명칭 정렬이며 필터/상세 로직과 앱 요청(`jobIds`)·응답(`availableJobs`) 형식은 변경되지 않습니다.

## 구현 내용 사항
- `ItemCategory` 엔티티를 `ItemJob`(`@Table(item_jobs)`, 컬럼 `job_category_id`)로 리네임했습니다.
- 아이템 검색/북마크 QueryDSL 필터를 `itemJob.jobCategoryId` 기준으로 갱신했습니다. (EXISTS / NOT EXISTS 구조·의미 동일)
- `JobRepository.findByItemId` JPQL을 `ItemJob` 조인(`job_id = job_category_id`)으로 갱신했습니다.
- transition 테스트를 `ItemJobRepositoryTransitionTest`로 리네임했습니다. (시나리오·기대값 동일)